### PR TITLE
Progress bar update during visualization of FE parts

### DIFF
--- a/vpmDB/FmFuncTree.C
+++ b/vpmDB/FmFuncTree.C
@@ -12,37 +12,37 @@
 #include "vpmDB/FmFuncTree.H"
 
 
-FmFuncStart::FmFuncStart(const std::string& UIString, const char** pixmap, int fUse)
-  : FmRingStart(UIString,pixmap)
+FmFuncStart::FmFuncStart(const std::string& uis, const char** pixmap, int fUse)
+: FmRingStart(uis,pixmap)
 {
   myFuncUse = fUse;
   myRingMemberType = FmMathFuncBase::getClassTypeID();
 }
 
 
-bool FmFuncStart::hasRingMembers() const
+bool FmFuncStart::hasRingMembers(bool) const
 {
   std::vector<FmMathFuncBase*> allFuncs;
-  FmSubAssembly* subAss = dynamic_cast<FmSubAssembly*>(this->getParentAssembly());
-  FmDB::getAllFunctions(allFuncs,subAss,true);
+  FmSubAssembly* sAss = dynamic_cast<FmSubAssembly*>(this->getParentAssembly());
+  FmDB::getAllFunctions(allFuncs,sAss,true);
 
-  for (size_t i = 0; i < allFuncs.size(); i++)
-    if (allFuncs[i]->getFunctionUse() == myFuncUse)
+  for (FmMathFuncBase* func : allFuncs)
+    if (func->getFunctionUse() == myFuncUse)
       return true;
 
   return false;
 }
 
 
-void FmFuncStart::getModelMembers(std::vector<FmModelMemberBase*>& list)
+void FmFuncStart::getModelMembers(std::vector<FmModelMemberBase*>& list) const
 {
   std::vector<FmMathFuncBase*> allFuncs;
-  FmSubAssembly* subAss = dynamic_cast<FmSubAssembly*>(this->getParentAssembly());
-  FmDB::getAllFunctions(allFuncs,subAss,true);
+  FmSubAssembly* sAss = dynamic_cast<FmSubAssembly*>(this->getParentAssembly());
+  FmDB::getAllFunctions(allFuncs,sAss,true);
 
-  for (size_t i = 0; i < allFuncs.size(); i++)
-    if (allFuncs[i]->getFunctionUse() == myFuncUse)
-      list.push_back(allFuncs[i]);
+  for (FmMathFuncBase* func : allFuncs)
+    if (func->getFunctionUse() == myFuncUse)
+      list.push_back(func);
 }
 
 
@@ -115,8 +115,8 @@ FmFuncTree::FmFuncTree(FmRingStart* root) : myNodes(15,NULL)
 
 FmFuncTree::~FmFuncTree()
 {
-  for (size_t i = 0; i < myNodes.size(); i++)
-    myNodes[i]->erase();
+  for (FmRingStart* node : myNodes)
+    node->erase();
 
   myHead->erase();
 }
@@ -124,6 +124,6 @@ FmFuncTree::~FmFuncTree()
 
 void FmFuncTree::setParentAssembly(FmBase* subAss)
 {
-  for (size_t i = 0; i < myNodes.size(); i++)
-    myNodes[i]->setParentAssembly(subAss);
+  for (FmRingStart* node : myNodes)
+    node->setParentAssembly(subAss);
 }

--- a/vpmDB/FmFuncTree.H
+++ b/vpmDB/FmFuncTree.H
@@ -14,14 +14,14 @@
 class FmFuncStart : public FmRingStart
 {
 public:
-  FmFuncStart(const std::string& UIString, const char** pixmap, int fUse);
+  FmFuncStart(const std::string& uis, const char** pixmap, int fUse);
   virtual ~FmFuncStart() {}
 
-  virtual bool hasRingMembers() const;
-  virtual void getModelMembers(std::vector<FmModelMemberBase*>& list);
+  virtual bool hasRingMembers(bool) const;
+  virtual void getModelMembers(std::vector<FmModelMemberBase*>& list) const;
 
   virtual void displayRingMembers() const {}
-  virtual bool eraseRingMembers(bool = false) { return true; }
+  virtual bool eraseRingMembers(bool) { return true; }
 
   virtual FmRingStart* searchFuncHead(int fUse) const;
 

--- a/vpmDB/FmRingStart.H
+++ b/vpmDB/FmRingStart.H
@@ -17,7 +17,7 @@ class FmRingStart : public FmModelMemberBase
   Fmd_HEADER_INIT();
 
 public:
-  FmRingStart(const std::string& UIString, const char** pixmap = NULL,
+  FmRingStart(const std::string& uistr, const char** pixmap = NULL,
               bool doPrintHeader = false);
   virtual ~FmRingStart() {}
 
@@ -31,7 +31,7 @@ public:
   void printHeader(bool doPrint) { myPrintHeader = doPrint; }
   bool printHeader() const { return myPrintHeader; }
   virtual int countRingMembers() const;
-  virtual bool hasRingMembers() const;
+  virtual bool hasRingMembers(bool noChildren = false) const;
   virtual void displayRingMembers() const;
   virtual bool eraseRingMembers(bool showProgress = false);
 
@@ -43,8 +43,8 @@ public:
   FmRingStart* getParent() const { return myParent; }
   const std::vector<FmRingStart*>& getChildren() const { return myChildren; }
 
-  virtual void getModelMembers(std::vector<FmModelMemberBase*>& list)
-  { this->getMembers(list); }
+  virtual void getModelMembers(std::vector<FmModelMemberBase*>& list) const
+  { const_cast<FmRingStart*>(this)->getMembers(list); }
 
   template<class T> void getMembers(std::vector<T*>& list)
   {
@@ -63,11 +63,14 @@ public:
 protected:
   void addChild(FmRingStart* child);
 
-  int                  myRingMemberType;
+private:
   std::string          myUIString;
   const char**         myPixmap;
   FmRingStart*         myParent;
   std::vector<FmRingStart*> myChildren;
+
+protected:
+  int myRingMemberType;
 
 private:
   bool myPrintHeader; //<! Should myUIString be used as a model file header?

--- a/vpmDB/FmTriad.C
+++ b/vpmDB/FmTriad.C
@@ -330,9 +330,9 @@ bool FmTriad::eraseOptions()
       {
         // The joint has two or less triads connected and this is one of them.
         // Try to erase the independent joint triads. Note: For line joints
-	// the independent triads  are assumed to always be in the same 
+        // the independent triads are assumed to always be in the same
         // assembly as the joint itself.
-        // Therefore we do not check for the other possibility here.
+        // Therefore, we do not check for the other possibility here.
         if (line)
         {
           static_cast<FmMMJointBase*>(joint)->setMaster(NULL);
@@ -984,7 +984,7 @@ bool FmTriad::showSymbol() const
   if (this->isMasterTriad() || this->isSlaveTriad())
     return false;
 
-  // Check if the triad is connected to at least one beam link
+  // Check if the triad is connected to at least one beam element
   // and no links of other type
   if (this->hasBeamBinding() && myAttachedLinks.empty())
     return FmDB::getActiveViewSettings()->visibleBeamTriads();
@@ -1139,7 +1139,7 @@ bool FmTriad::isAttached(const FmLink* link, bool exceptForThis) const
 
 /*!
   Check if this triad is attached to a link. If \a ignoreGPandEarth is \e true,
-  only FE links are considered. If \a allowMultipleLinks is \e false,
+  only FE parts are considered. If \a allowMultipleLinks is \e false,
   this method returns \e true only when the triad is attached to one single link
   and \e false if it is attached to more than one or not at all.
   If \a allowMultipleLinks is \e true, this method returns \e true no matter
@@ -1468,7 +1468,7 @@ FaMat34 FmTriad::getRelativeCS(const FmLink* link) const
 
 /*!
   Sets the position of this triad to be aligned with the provided matrix,
-  taking into account the link it could be attached to.
+  taking into account the part it could be attached to.
 
   If moveRelationsAlong == true, the triads in the joints this triad is a member
   of is moved as well, if the joints constraint system demands it.
@@ -1479,7 +1479,7 @@ FaMat34 FmTriad::getRelativeCS(const FmLink* link) const
 
 void FmTriad::setGlobalCS(const FaMat34& globalMat, bool moveRelationsAlong)
 {
-  FmLink* owner = this->getOwnerPart(0);
+  FmPart* owner = this->getOwnerPart(0);
 
   FaMat34 oldGlobalMat = this->getGlobalCS();
   if (owner)
@@ -2098,8 +2098,8 @@ int FmTriad::printAdditionalMass(FILE* fp)
 /*!
   This method is used in the Origin tab and the align CS commands
   to find out if it is possible to translate the triad.
-  If it is attached to an FE link, in a line joint, or in a point 
-  joint and its movability is connected to and "owning" joint,
+  If it is attached to an FE part, in a line joint, or in a point
+  joint and its movability is connected to an "owning" joint,
   then it is not allowed to translate it.
 */
 


### PR DESCRIPTION
Cosmetic fix: While generating the visualization of a multi-part model, this will ensure the progress bar in the bottom of the FEDEM GUI main window runs from 1 and up to the number of parts.

In addition, a Nastran parser bugfix is consumed via the submodule update.a

This will close SAP-archive/fedem-mdb#10 which this PR is replacing.