### PR TITLE
Minor bugfix and some refactoring

### DIFF
--- a/vpmDB/FmFileSys.C
+++ b/vpmDB/FmFileSys.C
@@ -32,7 +32,7 @@ std::string FmFileSys::getHomeDir()
   if (HOME) return HOME;
 
 #ifdef FT_HAS_QT
-  return QDir::homePath().toStdString();
+  return QDir::toNativeSeparators(QDir::homePath()).toStdString();
 #else
   return "";
 #endif

--- a/vpmDB/FmLink.C
+++ b/vpmDB/FmLink.C
@@ -146,7 +146,7 @@ bool FmLink::isCADLoaded() const
 {
 #ifdef USE_INVENTOR
   if (itsDisplayPt)
-    if (((FdLink*)itsDisplayPt)->getCadComponent())
+    if (static_cast<FdLink*>(itsDisplayPt)->getCadComponent())
       return true;
 #endif
   return false;
@@ -161,9 +161,22 @@ bool FmLink::isUsingGenPartVis() const
 {
 #ifdef USE_INVENTOR
   if (itsDisplayPt)
-    return ((FdLink*)itsDisplayPt)->isUsingGenPartVis();
+    return static_cast<FdLink*>(itsDisplayPt)->isUsingGenPartVis();
 #endif
   return false;
+}
+
+
+/*!
+  Updates the simplified generic part visualization.
+*/
+
+void FmLink::updateGPVisualization()
+{
+#ifdef USE_INVENTOR
+  if (itsDisplayPt && this->isGenericPart())
+    static_cast<FdLink*>(itsDisplayPt)->updateSimplifiedViz();
+#endif
 }
 
 
@@ -754,7 +767,7 @@ FaVec3 FmLink::getExtents() const
 bool FmLink::getBBox(FaVec3& max, FaVec3& min) const
 {
 #ifdef USE_INVENTOR
-  if (((FdLink*)itsDisplayPt)->getGenPartBoundingBox(max,min))
+  if (static_cast<FdLink*>(itsDisplayPt)->getGenPartBoundingBox(max,min))
     return true;
 #endif
 
@@ -930,7 +943,7 @@ bool FmLink::openCadData()
   if (!in)
     ListUI <<"  -> Error: Could not open "<< filename <<" for reading.\n";
   else if (itsDisplayPt)
-    return ((FdLink*)itsDisplayPt)->readCad(in);
+    return static_cast<FdLink*>(itsDisplayPt)->readCad(in);
 #endif
 
   return false;
@@ -949,7 +962,7 @@ bool FmLink::saveCadData()
 #ifdef USE_INVENTOR
   else if (itsDisplayPt)
   {
-    ((FdLink*)itsDisplayPt)->writeCad(os);
+    static_cast<FdLink*>(itsDisplayPt)->writeCad(os);
     return true;
   }
 #endif

--- a/vpmDB/FmLink.H
+++ b/vpmDB/FmLink.H
@@ -139,6 +139,7 @@ public:
   bool saveCadData();
   bool isCADLoaded() const;
   bool isUsingGenPartVis() const;
+  void updateGPVisualization();
 
   virtual std::string getAbsFilePath(bool createDir = false) const;
   std::string getBaseCadFile(bool createDir = false) const;

--- a/vpmDB/FmMechanism.C
+++ b/vpmDB/FmMechanism.C
@@ -385,3 +385,9 @@ void FmMechanism::syncPath(const std::string& name, bool updateRSD)
     this->getResultStatusData(false)->copy(this->getResultStatusData());
   }
 }
+
+
+std::string FmMechanism::getRelativePath(const std::string& fullName) const
+{
+  return FFaFilePath::getRelativeFilename(myAbsModelFilePath,fullName);
+}

--- a/vpmDB/FmMechanism.H
+++ b/vpmDB/FmMechanism.H
@@ -39,6 +39,7 @@ public:
   const std::string& getAbsModelFilePath() const { return myAbsModelFilePath; }
   const std::string& getAbsModelRDBPath() const  { return myAbsModelRDBPath; }
 
+  std::string getRelativePath(const std::string& fullName) const;
   std::string getModelName(bool keepExt = false) const;
   std::string getAbsModelLRDBPath(bool createDir = false) const;
   std::string getPropertyLibPath(bool createDir = true) const;

--- a/vpmDB/FmPart.C
+++ b/vpmDB/FmPart.C
@@ -1065,8 +1065,7 @@ void FmPart::updateMassProperties()
     {
       ListUI <<"  -> Calculating mass properties for "<< this->getIdString(true)
              <<"\n     based on CAD geometry in "
-             << FFaFilePath::getRelativeFilename(FmDB::getMechanismObject()->getAbsModelFilePath(),cadFile)
-             <<"\n";
+             << FmDB::getMechanismObject()->getRelativePath(cadFile) <<"\n";
       double Volume = 0.0;
       FFaTensor3 Inertia;
       FFaBody::prefix = FFaFilePath::getPath(cadFile);
@@ -1394,10 +1393,7 @@ bool FmPart::importPart(const std::string& fileName,
   // Set the name of the imported FE data file
   std::string newFEFile;
   if (storeRelativePath)
-  {
-    const std::string& path = FmDB::getMechanismObject()->getAbsModelFilePath();
-    newFEFile = FFaFilePath::getRelativeFilename(path,fileName);
-  }
+    newFEFile = FmDB::getMechanismObject()->getRelativePath(fileName);
   else
     newFEFile = fileName;
 
@@ -1504,8 +1500,7 @@ bool FmPart::importPart(const std::string& fileName,
   else if (FFaFilePath::isExtension(fileName,"ftl"))
   {
     // Lambda function checking for externally reduced matrix file
-    const std::string& path = FmDB::getMechanismObject()->getAbsModelFilePath();
-    auto&& checkExt = [path,fileName](FFaField<std::string>& field, char mType)
+    auto&& checkExt = [fileName](FFaField<std::string>& field, char mType)
     {
       std::string matrixFile = FFaFilePath::getBaseName(fileName);
       matrixFile.append(1,'_');
@@ -1519,7 +1514,7 @@ bool FmPart::importPart(const std::string& fileName,
       if (!FmFileSys::isFile(matrixFile))
         return false;
 
-      field.setValue(FFaFilePath::getRelativeFilename(path,matrixFile));
+      field.setValue(FmDB::getMechanismObject()->getRelativePath(matrixFile));
       ListUI <<"  -> Using externally reduced "<< field.getValue() <<"\n";
       return true;
     };
@@ -1874,12 +1869,11 @@ bool FmPart::convertOP2files(const std::string& absPartPath)
 
   // The S, M and G fmx-files should now reside in the directory absPartPath
   myFEData->clearOP2files();
-  const std::string& mPath = FmDB::getMechanismObject()->getAbsModelFilePath();
-  std::string partPath = FFaFilePath::getRelativeFilename(mPath,absPartPath);
-  FFaFilePath::appendToPath(partPath,FFaFilePath::getFileName(partName));
-  SMatFile.setValue(partPath + "_S.fmx");
-  MMatFile.setValue(partPath + "_M.fmx");
-  GMatFile.setValue(partPath + "_G.fmx");
+  std::string path = FmDB::getMechanismObject()->getRelativePath(absPartPath);
+  FFaFilePath::appendToPath(path,FFaFilePath::getFileName(partName));
+  SMatFile.setValue(path + "_S.fmx");
+  MMatFile.setValue(path + "_M.fmx");
+  GMatFile.setValue(path + "_G.fmx");
   return true;
 }
 

--- a/vpmDB/FmPart.H
+++ b/vpmDB/FmPart.H
@@ -154,6 +154,7 @@ public:
   double getConnectorTolerance() const;
   char isTriadConnectable(FmTriad* triad) const;
 #ifdef FT_USE_CONNECTORS
+  void updateConnectorVisualization();
   bool createConnector(const IntVec& nodes, const FaVec3& refNodePos,
                        FmTriad* triad = NULL, int spiderType = 0);
   bool createConnector(const FFaCompoundGeometry& geometry,

--- a/vpmDB/FmTriad.C
+++ b/vpmDB/FmTriad.C
@@ -866,8 +866,8 @@ bool FmTriad::disconnect()
       for (size_t i = 0; i < connector.size(); i++)
         if (connector[i]->getAddExclude())
           FdExtraGraphics::highlight(connector[i],owner->getGlobalCS(),false);
-      static_cast<FdPart*>(owner->getFdPointer())->updateConnectorElements();
 #endif
+      owner->updateConnectorVisualization();
       connector.deleteGeometry();
     }
 #endif
@@ -889,12 +889,8 @@ bool FmTriad::disconnect()
   if (owner)
   {
     this->setGlobalCS(owner->getGlobalCS() * this->getLocalCS());
-
-#ifdef USE_INVENTOR
-    // Redraw generic part spider after removal of this triad
-    if (owner->useGenericProperties.getValue())
-      static_cast<FdPart*>(owner->getFdPointer())->updateSimplifiedViz();
-#endif
+    // Redraw generic part spider (if any) after removal of this triad
+    owner->updateGPVisualization();
   }
 
   return true;
@@ -1653,11 +1649,9 @@ void FmTriad::updateChildrenDisplayTopology()
   for (FmTire* tire : tires)
     tire->updateTopologyInViewer();
 
-  // Update attached generic parts
   myAttachedLinks.getPtrs(links);
   for (FmLink* link : links)
-    if (link->isGenericPart())
-      static_cast<FdLink*>(link->getFdPointer())->updateSimplifiedViz();
+    link->updateGPVisualization();
 
   FmHasDOFsBase::updateChildrenDisplayTopology();
 #endif

--- a/vpmDB/FmcOutput.C
+++ b/vpmDB/FmcOutput.C
@@ -162,6 +162,7 @@ bool FmcOutput::cloneLocal(FmBase* obj, int depth)
   FmCtrlLine* cpLine = copyObj->getLine();
   copyObj->setLine(1,NULL);
   this->setLine(1,cpLine);
+
   return true;
 }
 
@@ -178,7 +179,9 @@ bool FmcOutput::setLine(int portNo, FmCtrlLine* line)
     return false;
 
   itsInput = line;
-  line->setEndElement(this);
+  if (line)
+    line->setEndElement(this);
+
   return true;
 }
 
@@ -188,8 +191,10 @@ bool FmcOutput::releaseFromPort(FmCtrlLine* line)
   if (line != itsInput)
     return false;
 
-  line->setEndElement(NULL);
+  if (line)
+    line->setEndElement(NULL);
   itsInput = NULL;
+
   return true;
 }
 


### PR DESCRIPTION
The third commit here fixes the problem that sometimes the geometry visualisation files for generic parts gets wrong path when imported into the FEDEM GUI on Windows, since QDIR::homePath() always returns the path using "/ " as separators (Unix style).

The other two commits add some convenience methods for updating the spider visualisation of connectors and generic parts, and for obtaining the relative path with respect to the model file location.