### PR TITLE
Fix issue openfedem/fedem-gui#37: Don't check argument range during clone

### DIFF
--- a/vpmDB/FmEngine.H
+++ b/vpmDB/FmEngine.H
@@ -56,7 +56,7 @@ public:
   bool getValue(double x, double& y) const;
 
   void setFunction(FmMathFuncBase* func);
-  void setSensor(FmSensorBase* sensor, size_t i = 0);
+  void setSensor(FmSensorBase* sensor, int argIdx = 0);
 
   void setEntityName(const std::string& name, size_t i = 0);
   void setEntity(int ent, size_t i = 0);

--- a/vpmDB/FmFileSys.C
+++ b/vpmDB/FmFileSys.C
@@ -332,10 +332,11 @@ int FmFileSys::getNextDirIncrement(const std::string& dirName,
     return 1;
 
   int retvar = 1;
-  for (const std::string& dir : dirs)
+  for (const std::string& dirName : dirs)
   {
+    std::string dir = FFaFilePath::getBaseName(dirName);
     size_t us = dir.rfind("_");
-    if (us+1 < dir.size() && dir.substr(0,us) == baseDirName)
+    if (us+1 < dir.size())
     {
       int ver = atoi(dir.substr(us+1).c_str());
       if (ver+1 > retvar) retvar = ver+1;

--- a/vpmDB/FmGraph.H
+++ b/vpmDB/FmGraph.H
@@ -89,11 +89,11 @@ public:
   virtual const char* getUITypeName() const;
 
   //! \brief Returns the valid ASCII file extensions.
-  static std::vector<std::string> asc() { return { "asc", "txt" }; }
+  static Strings asc() { return { "asc", "csv", "txt" }; }
   //! \brief Returns the valid DAC file extensions.
-  static std::vector<std::string> dac() { return { "dac" }; }
+  static Strings dac() { return { "dac" }; }
   //! \brief Returns the valid RPC file extensions.
-  static std::vector<std::string> rpc() { return { "rsp", "drv", "tim" }; }
+  static Strings rpc() { return { "rsp", "drv", "tim" }; }
 
 protected:
   virtual ~FmGraph();


### PR DESCRIPTION
This fixes openfedem/fedem-gui#37 when consumed in that repository.

The problem was that we check if the argument index is within the valid range by checking the number of arguments of the assigned math function object, when cloning the engine object. But the math function pointer is not resolved at this point and therefore the test will always fail, with the result that only the first argument sensor is assigned.

By supplying a negative argument index instead, the check is by-passed.

Finally, the third commit fixes openfedem/fedem-gui#34. It boiled down to a bug in the extraction of the task version number from the directories of existing reductions, such that the existing directory was overwritten by the second part using the same FE data file.