### PR TITLE
Add time-dependent mass scaling engines as beta feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,8 @@ endif ( GTest_FOUND )
 
 # Build and install the shared library
 message ( STATUS "Building shared library ${LIB_ID}" )
-add_library ( ${LIB_ID} SHARED FedemDB.C )
+add_library ( ${LIB_ID} SHARED FedemDB.C
+              fedem-foundation/src/FFaLib/FFaCmdLineArg/FFaOptionFileCreator.C )
 target_link_libraries ( ${LIB_ID} vpmDB )
 
 install ( TARGETS ${LIB_ID}

--- a/FedemDB.C
+++ b/FedemDB.C
@@ -56,7 +56,6 @@
 #include "FFlLib/FFlMemPool.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
 
-#include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
 #include "FFaLib/FFaOS/FFaFilePath.H"
 
@@ -191,15 +190,6 @@ DLLexport(void) FmInit (const char* plugin1, const char* plugin2)
   if (plugin2) std::cout <<"\tPlugin2 = "<< plugin2 << std::endl;
 #endif
 
-  const char* program = "FedemDB";
-  FFaCmdLineArg::init(1,const_cast<char**>(&program));
-  // Add command-line options that will be attempted evaluated
-  FFaCmdLineArg::instance()->addOption("memPoll",false,"Stop execution for memory polling");
-  FFaCmdLineArg::instance()->addOption("allow3DofAttach",true,"Allow triads to be attached to 3-DOF nodes");
-  FFaCmdLineArg::instance()->addOption("allowDepAttach",false,"Allow triads to be attached to dependent RGD nodes");
-  FFaCmdLineArg::instance()->addOption("convertToLinear",1,"Convert parabolic shell and beam elements to linears");
-  FFaCmdLineArg::instance()->addOption("ID_increment",0,"User ID increment");
-  FFaCmdLineArg::instance()->addOption("reUseUserID",false,"Fill holes in user ID range");
   // Initialize the model database data structure
   FmDB::init();
 
@@ -317,7 +307,6 @@ DLLexport(void) FmClose (bool removeSingletons = false)
   if (removeSingletons)
   {
     FmDB::removeInstances();
-    FFaCmdLineArg::removeInstance();
     FFaUserFuncPlugin::removeInstance();
     FiUserElmPlugin::removeInstance();
   }

--- a/test/test_FmPart.C
+++ b/test/test_FmPart.C
@@ -18,7 +18,6 @@
 #include "vpmDB/Icons/FmIconPixmapsMain.H"
 #include "FFlLib/FFlLinkHandler.H"
 #include "FFlLib/FFlFEParts/FFlNode.H"
-#include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
 
 static std::string srcdir; //!< Full path of the source directory of this test
 
@@ -35,20 +34,16 @@ int main (int argc, char** argv)
 
   // Extract the source directory of the tests
   // to use as prefix for loading external files
-  int numarg = 0;
   for (int i = 1; i < argc; i++)
     if (!strncmp(argv[i],"--srcdir=",9))
     {
       srcdir = argv[i]+9;
       std::cout <<"Note: Source directory = "<< srcdir << std::endl;
       if (srcdir.back() != '/') srcdir += '/';
+      break;
     }
-    else if (++numarg < i)
-      argv[numarg] = argv[i];
 
   // Initialize the Fedem mechanism database
-  FFaCmdLineArg::init(numarg,argv);
-  FFaCmdLineArg::instance()->addOption("reUseUserID",false,"Fill holes in user ID range");
   FmDB::init();
 
   // Invoke the google test driver
@@ -56,7 +51,6 @@ int main (int argc, char** argv)
 
   // Clean up heap memory
   FmDB::removeInstances();
-  FFaCmdLineArg::removeInstance();
   return status;
 }
 

--- a/test/test_creators.C
+++ b/test/test_creators.C
@@ -14,7 +14,6 @@
 #include "assemblyCreators/turbineConverter.H"
 #include "vpmDB/FmDB.H"
 #include "vpmDB/Icons/FmIconPixmapsMain.H"
-#include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
 
 static std::string srcdir; //!< Full path of the source directory of this test
 
@@ -31,20 +30,16 @@ int main (int argc, char** argv)
 
   // Extract the source directory of the tests
   // to use as prefix for loading external files
-  int numarg = 0;
   for (int i = 1; i < argc; i++)
     if (!strncmp(argv[i],"--srcdir=",9))
     {
       srcdir = argv[i]+9;
       std::cout <<"Note: Source directory = "<< srcdir << std::endl;
       if (srcdir.back() != '/') srcdir += '/';
+      break;
     }
-    else if (++numarg < i)
-      argv[numarg] = argv[i];
 
   // Initialize the Fedem mechanism database
-  FFaCmdLineArg::init(numarg,argv);
-  FFaCmdLineArg::instance()->addOption("reUseUserID",false,"Fill UID holes");
   FmDB::init();
 
   // Invoke the google test driver
@@ -52,7 +47,6 @@ int main (int argc, char** argv)
 
   // Clean up model-independent heap memory
   FmDB::removeInstances();
-  FFaCmdLineArg::removeInstance();
   return status;
 }
 

--- a/vpmDB/CMakeLists.txt
+++ b/vpmDB/CMakeLists.txt
@@ -123,11 +123,15 @@ endforeach ( FILE ${HPP_FILE_LIST} )
 
 
 set ( FT_COMMON_LIBRARIES Admin FFlIOAdaptors FFlFEParts FFlLib
-                          FFaAlgebra FFaCmdLineArg FFaContainers FFaDefinitions
+                          FFaAlgebra FFaContainers FFaDefinitions
                           FFaDynCalls FFaOS FFaTypeCheck )
 if ( USE_CONNECTORS )
   list ( INSERT FT_COMMON_LIBRARIES 9 FFaGeometry )
 endif ( USE_CONNECTORS )
+if ( USE_CMDLINEARG )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_CMDLINEARG" )
+  list ( INSERT FT_COMMON_LIBRARIES 5 FFaCmdLineArg )
+endif ( USE_CMDLINEARG )
 
 set ( FT_KERNEL_LIBRARIES FiDeviceFunctions FiUserElmPlugin
                           FFaFunctionLib FFaMathExpr )

--- a/vpmDB/FmBase.C
+++ b/vpmDB/FmBase.C
@@ -9,7 +9,9 @@
 #include "vpmDB/FmRingStart.H"
 #include "vpmDB/FmSubAssembly.H"
 #include "vpmDB/FmDB.H"
+#ifdef FT_USE_CMDLINEARG
 #include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
+#endif
 #include "FFaLib/FFaString/FFaStringExt.H"
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
 #include "FFaLib/FFaString/FFaParse.H"
@@ -243,6 +245,7 @@ bool FmBase::mainConnect(bool allowNonUniqueIDs)
   }
   else
   {
+#ifdef FT_USE_CMDLINEARG
     bool reuseUserID = false;
     FFaCmdLineArg::instance()->getValue("reUseUserID",reuseUserID);
     if (reuseUserID)
@@ -255,6 +258,7 @@ bool FmBase::mainConnect(bool allowNonUniqueIDs)
              afterPt->itsNextRingPt->getID() - afterPt->getID() == 1)
         afterPt = afterPt->itsNextRingPt;
     }
+#endif
     this->setID(afterPt->getID() + 1);
   }
 

--- a/vpmDB/FmBeam.C
+++ b/vpmDB/FmBeam.C
@@ -753,6 +753,13 @@ int FmBeam::printSolverEntry(FILE* fp, int propId, FmBeamProperty* bProp,
     FmEngine::betaFeatureEngines.insert(stifSclEngine);
   }
 
+  // Beta feature: Time-dependent mass scaling
+  int massSclEngine = bDesc.getIntAfter("#MassScaleEngine");
+  if (massSclEngine > 0) {
+    fprintf(fp,"  massEngineId = %d\n", massSclEngine);
+    FmEngine::betaFeatureEngines.insert(massSclEngine);
+  }
+
   // Structural damping coefficients
   fprintf(fp,"  alpha1 =%17.9e," , alpha1.getValue());
   fprintf(fp,"  alpha2 =%17.9e\n", alpha2.getValue());

--- a/vpmDB/FmCurveSet.H
+++ b/vpmDB/FmCurveSet.H
@@ -320,7 +320,7 @@ protected:
   FFaField<std::string>           myExpression;
   FFaReferenceList<FmCurveSet>    myCurves;
   FFaField<FFaReferenceListBase*> myCurvesField;
-  std::vector<bool>               myActiveCurves;
+  std::set<size_t>                myActiveCurves;
 
   FFaReferenceList<FmIsPlottedBase> mySpatialObjects;
   FFaField<FFaReferenceListBase*>   mySpatialObjectsField;

--- a/vpmDB/FmDB.C
+++ b/vpmDB/FmDB.C
@@ -89,7 +89,9 @@
 #ifdef USE_INVENTOR
 #include "vpmDisplay/FdDB.H"
 #endif
+#ifdef FT_USE_CMDLINEARG
 #include "FFaLib/FFaCmdLineArg/FFaCmdLineArg.H"
+#endif
 #include "FFaLib/FFaDefinitions/FFaAppInfo.H"
 #include "FFaLib/FFaOS/FFaFilePath.H"
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
@@ -2334,6 +2336,7 @@ bool FmDB::readAll(const std::string& name, char ignoreFileVersion)
 
   FFaMsg::setSubTask("");
 
+#ifdef FT_USE_CMDLINEARG
   int incID = 0;
   FFaCmdLineArg::instance()->getValue("ID_increment",incID);
   if (incID > 0) {
@@ -2344,6 +2347,7 @@ bool FmDB::readAll(const std::string& name, char ignoreFileVersion)
         for (FmBase* p = head.second->getNext(); p != head.second; p = p->getNext())
           p->setID(p->getID() + incID);
   }
+#endif
 
   // Conversion of old-style generic DB objects to cross sections and materials.
   // Before R7.0, we used a generic DB object that contained material, geometry

--- a/vpmDB/FmSolverParser.C
+++ b/vpmDB/FmSolverParser.C
@@ -604,6 +604,13 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
       FmEngine::betaFeatureEngines.insert(stifSclEngine);
     }
 
+    // Beta feature: Time-dependent mass scaling
+    int massSclEngine = lDesc.getIntAfter("#MassScaleEngine");
+    if (massSclEngine > 0) {
+      fprintf(myFile,"  massEngineId = %d\n", massSclEngine);
+      FmEngine::betaFeatureEngines.insert(massSclEngine);
+    }
+
     // Structural damping coefficients
     fprintf(myFile,"  alpha1 =%17.9e," ,activePart->alpha1.getValue());
     fprintf(myFile,"  alpha2 =%17.9e\n",activePart->alpha2.getValue());


### PR DESCRIPTION
This fixes openfedem/fedem-gui#44 when consumed in the repository.
Requires openfedem/fedem-solvers#19.

The last commit fixes openfedem/fedem-gui#45. That problem occurred because the new curve objects that was created when copying them were connected to owner graph of the copied curves, _before_ they were moved to the new graph of the other graph group (sub-assembly). But then they were assigned an incorrect user ID (unique within the sub-assembly of the copied curves) which they will take with them to the new sub-assembly. The result was that all the copied curves got assigned the same user ID, and therefore only the first one showed up in the Results tree. The fix is therefore to skip the connection step in the copy operation, before moving them.