### PR TITLE
Fix issue openfedem/fedem-gui#56: Revert change from Apr 2023

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # This is the top-level cmake project file for the Fedem model database library.
 ################################################################################
 
-cmake_minimum_required ( VERSION 2.8...3.5 )
+cmake_minimum_required ( VERSION 2.8...3.10 )
 
 # Project setup
 

--- a/chainShape/Minpack/src/enorm.f
+++ b/chainShape/Minpack/src/enorm.f
@@ -1,4 +1,5 @@
       double precision function enorm(n,x)
+      implicit none
       integer n
       double precision x(n)
 c     **********
@@ -39,9 +40,11 @@ c     burton s. garbow, kenneth e. hillstrom, jorge j. more
 c
 c     **********
       integer i
-      double precision agiant,floatn,one,rdwarf,rgiant,s1,s2,s3,xabs,
-     *                 x1max,x3max,zero
-      data one,zero,rdwarf,rgiant /1.0d0,0.0d0,3.834d-20,1.304d19/
+      double precision agiant,floatn,s1,s2,s3,xabs,x1max,x3max
+      double precision one,zero,rdwarf,rgiant
+      parameter ( one = 1.0d0, zero = 0.0d0 )
+      parameter ( rdwarf = 3.834d-20, rgiant = 1.304d19 )
+C
       s1 = zero
       s2 = zero
       s3 = zero
@@ -49,58 +52,51 @@ c     **********
       x3max = zero
       floatn = n
       agiant = rgiant/floatn
-      do 90 i = 1, n
+      do i = 1, n
          xabs = dabs(x(i))
-         if (xabs .gt. rdwarf .and. xabs .lt. agiant) go to 70
-            if (xabs .le. rdwarf) go to 30
+         if (xabs .ge. agiant) then
 c
-c              sum for large components.
+c           sum for large components.
 c
-               if (xabs .le. x1max) go to 10
-                  s1 = one + s1*(x1max/xabs)**2
-                  x1max = xabs
-                  go to 20
-   10          continue
-                  s1 = s1 + (xabs/x1max)**2
-   20          continue
-               go to 60
-   30       continue
+            if (xabs .gt. x1max) then
+               s1 = one + s1*(x1max/xabs)**2
+               x1max = xabs
+            else
+               s1 = s1 + (xabs/x1max)**2
+            endif
 c
-c              sum for small components.
+         else if (xabs .le. rdwarf) then
 c
-               if (xabs .le. x3max) go to 40
-                  s3 = one + s3*(x3max/xabs)**2
-                  x3max = xabs
-                  go to 50
-   40          continue
-                  if (xabs .ne. zero) s3 = s3 + (xabs/x3max)**2
-   50          continue
-   60       continue
-            go to 80
-   70    continue
+c           sum for small components.
+c
+            if (xabs .gt. x3max) then
+               s3 = one + s3*(x3max/xabs)**2
+               x3max = xabs
+            else if (xabs .ne. zero) then
+               s3 = s3 + (xabs/x3max)**2
+            end if
+c
+         else
 c
 c           sum for intermediate components.
 c
-            s2 = s2 + xabs**2
-   80    continue
-   90    continue
+            s2 = s2 + xabs*xabs
+c
+         end if
+      end do
 c
 c     calculation of norm.
 c
-      if (s1 .eq. zero) go to 100
+      if (s1 .ne. zero) then
          enorm = x1max*dsqrt(s1+(s2/x1max)/x1max)
-         go to 130
-  100 continue
-         if (s2 .eq. zero) go to 110
-            if (s2 .ge. x3max)
-     *         enorm = dsqrt(s2*(one+(x3max/s2)*(x3max*s3)))
-            if (s2 .lt. x3max)
-     *         enorm = dsqrt(x3max*((s2/x3max)+(x3max*s3)))
-            go to 120
-  110    continue
-            enorm = x3max*dsqrt(s3)
-  120    continue
-  130 continue
+      else if (s2 .eq. zero) then
+         enorm = x3max*dsqrt(s3)
+      else if (s2 .ge. x3max) then
+         enorm = dsqrt(s2*(one+(x3max/s2)*(x3max*s3)))
+      else
+         enorm = dsqrt(x3max*((s2/x3max)+(x3max*s3)))
+      end if
+c
       return
 c
 c     last card of function enorm.

--- a/chainShape/Minpack/src/lmder.f
+++ b/chainShape/Minpack/src/lmder.f
@@ -381,9 +381,11 @@ c
 c           update the step bound.
 c
             if (ratio .gt. p25) go to 240
-               if (actred .ge. zero) temp = p5
-               if (actred .lt. zero)
-     *            temp = p5*dirder/(dirder + p5*actred)
+               if (actred .lt. zero) then
+                  temp = p5*dirder/(dirder + p5*actred)
+               else
+                  temp = p5
+               end if
                if (p1*fnorm1 .ge. fnorm .or. temp .lt. p1) temp = p1
                delta = temp*dmin1(delta,pnorm/p1)
                par = par/temp

--- a/vpmDB/FmBeam.H
+++ b/vpmDB/FmBeam.H
@@ -86,6 +86,7 @@ public:
   virtual bool clone(FmBase* obj, int depth);
   virtual void initAfterResolve();
 
+  using FmLink::printSolverEntry;
   int printSolverEntry(FILE* fp, int propId, FmBeamProperty* bProp, const std::string* rdbPath);
   virtual int printSolverEntry(FILE* fp, int propId) { return this->printSolverEntry(fp,propId,NULL,NULL); }
   virtual bool writeToVTF(VTFAFile& file, IntVec*, IntVec*);

--- a/vpmDB/FmLink.C
+++ b/vpmDB/FmLink.C
@@ -531,10 +531,10 @@ bool FmLink::attachTriad(FmTriad* attachTr, bool isSilent, bool doUpdate)
 #endif
 
   // Lambda function for checking if two triads are on a common joint
-  std::function<bool(FmTriad*,FmTriad*)> onJoint = [](FmTriad* tr1, FmTriad* tr2)
+  std::function<bool(FmTriad*,FmTriad*)> onJoint = [](FmTriad* t1, FmTriad* t2)
   {
-    FmJointBase* jnt = tr1->getJointWhereSlave();
-    return jnt ? jnt->isMasterTriad(tr2) : false;
+    FmJointBase* jnt = t1->getJointWhereSlave();
+    return jnt ? jnt->isMasterTriad(t2) : false;
   };
 
   FmTriad* oldTr = NULL;
@@ -563,11 +563,10 @@ bool FmLink::attachTriad(FmTriad* attachTr, bool isSilent, bool doUpdate)
     return false;
   else if (!this->isOfType(FmPart::getClassTypeID()))
     attachTr = oldTr; // The old existing triad is used instead
-  else
-    attachTr = NULL; // Don't need to update visualization for Triads on Parts
+  // else this is an FmPart, the attachTr is used and oldTr was erased
 
   this->onChanged();
-  if (!doUpdate || !attachTr)
+  if (!doUpdate)
     return true;
 
   // Update the triad visualization
@@ -723,9 +722,9 @@ bool FmLink::isTriadAttachable(FmTriad*& existingTriad,
 
 std::pair<FmTriad*,bool> FmLink::getExistingTriad(const FmTriad* triad)
 {
-  FmTriad* existingTr = this->getTriadAtPoint(triad->getGlobalTranslation(),
-					      FmDB::getPositionTolerance(),true);
-  return std::make_pair(existingTr,true);
+  FmTriad* oldTr = this->getTriadAtPoint(triad->getGlobalTranslation(),
+                                         FmDB::getPositionTolerance(),true);
+  return { oldTr, true };
 }
 
 

--- a/vpmDB/FmLoad.H
+++ b/vpmDB/FmLoad.H
@@ -51,8 +51,8 @@ public:
   void setLocalFromPoint(const FaVec3& pt) { this->setLocalPoint(pt,0); }
   void setLocalToPoint(const FaVec3& pt)   { this->setLocalPoint(pt,1); }
 
-  FaVec3 getGlobalFromPoint() const { return std::move(this->getGlbPoint(0)); }
-  FaVec3 getGlobalToPoint()   const { return std::move(this->getGlbPoint(1)); }
+  FaVec3 getGlobalFromPoint() const { return this->getGlbPoint(0); }
+  FaVec3 getGlobalToPoint()   const { return this->getGlbPoint(1); }
   void setGlobalFromPoint(const FaVec3& pt) { this->setGlbPoint(pt,0); }
   void setGlobalToPoint(const FaVec3& pt)   { this->setGlbPoint(pt,1); }
 


### PR DESCRIPTION
The Coverty scanning performed back then claimed that the `attachTr` pointer could be used after being erased (by the virtual `FmLink::attachTriad()` method), but clearly the scanner did not see that the overridden method in the sub-class `FmPart` does not erase it. Therefore, we should _not_ skip the visualization update when attaching to a `FmPart` object, which caused the rendering incorrect after the attach operation was finished.

This fixes openfedem/fedem-gui#56.