### PR TITLE
Change to bool return type for some asignment methods

### DIFF
--- a/vpmDB/FmAssemblyBase.C
+++ b/vpmDB/FmAssemblyBase.C
@@ -19,7 +19,6 @@ FmAssemblyBase::FmAssemblyBase(bool isDummy) : FmSubAssembly(isDummy)
 
   FFA_FIELD_DEFAULT_INIT(myCS,"COORDINATE_SYSTEM");
   FFA_FIELD_DEFAULT_INIT(myLocation,"LOCATION3D_DATA");
-  myLocation.getValue().setSaveNumericalData(false);
 }
 
 

--- a/vpmDB/FmIsPositionedBase.C
+++ b/vpmDB/FmIsPositionedBase.C
@@ -20,7 +20,6 @@ FmIsPositionedBase::FmIsPositionedBase()
 
   FFA_FIELD_DEFAULT_INIT(myCS, "COORDINATE_SYSTEM");
   FFA_FIELD_DEFAULT_INIT(myLocation, "LOCATION3D_DATA");
-  myLocation.getValue().setSaveNumericalData(false);
 
   FFA_REFERENCE_FIELD_INIT(myPosRefField, myPosRef, "LOCATION3D_POS_VIEW_REF");
   FFA_REFERENCE_FIELD_INIT(myRotRefField, myRotRef, "LOCATION3D_ROT_VIEW_REF");

--- a/vpmDB/FmPart.C
+++ b/vpmDB/FmPart.C
@@ -1011,6 +1011,17 @@ int FmPart::getNodePos(int nodeNo, double* x, double* y, double* z) const
 }
 
 
+bool FmPart::getNodeConnectivity(int nodeNo, Strings& elements) const
+{
+  if (myFEData)
+    myFEData->getNodeConnectivity(nodeNo,elements);
+  else
+    elements.clear();
+
+  return !elements.empty();
+}
+
+
 FFlNode* FmPart::getClosestNode(const FaVec3& point) const
 {
   return myFEData ? myFEData->findClosestNode(point) : NULL;
@@ -2811,9 +2822,10 @@ bool FmPart::isTranslatable() const
 }
 
 
-void FmPart::setCGPosRef(FmIsPositionedBase* refObj)
+bool FmPart::setCGPosRef(FmIsPositionedBase* refObj)
 {
-  if (myCGPosRef == refObj) return;
+  if (myCGPosRef == refObj)
+    return false; // not changed
 
   FaMat34 newRefCS;
   FaMat34 oldRefCS;
@@ -2824,12 +2836,14 @@ void FmPart::setCGPosRef(FmIsPositionedBase* refObj)
   myCG.getValue().changePosRefCS(newRefCS,oldRefCS);
 
   myCGPosRef = refObj;
+  return true;
 }
 
 
-void FmPart::setCGRotRef(FmIsPositionedBase* refObj)
+bool FmPart::setCGRotRef(FmIsPositionedBase* refObj)
 {
-  if (myCGRotRef == refObj) return;
+  if (myCGRotRef == refObj)
+    return false; // not changed
 
   FaMat34 newRefCS;
   FaMat34 oldRefCS;
@@ -2840,6 +2854,7 @@ void FmPart::setCGRotRef(FmIsPositionedBase* refObj)
   myCG.getValue().changeRotRefCS(newRefCS,oldRefCS);
 
   myCGRotRef = refObj;
+  return true;
 }
 
 

--- a/vpmDB/FmPart.H
+++ b/vpmDB/FmPart.H
@@ -77,6 +77,7 @@ public:
   FFlNode* getNode(int nodeNo) const;
   int getNodePos(int nodeNo,
                  double* x = NULL, double* y = NULL, double* z = NULL) const;
+  bool getNodeConnectivity(int nodeNo, Strings& elements) const;
   FFlNode* getClosestNode(const FaVec3& point) const;
 
   int  getCompModesFlags(IntVec& BCcodes) const;
@@ -111,8 +112,8 @@ public:
 
   virtual void getStickers(std::vector<FmSticker*>& toFill) const;
 
-  void setCGPosRef(FmIsPositionedBase* ref);
-  void setCGRotRef(FmIsPositionedBase* ref);
+  bool setCGPosRef(FmIsPositionedBase* ref);
+  bool setCGRotRef(FmIsPositionedBase* ref);
 
   FmIsPositionedBase* getCGPosRef() const { return myCGPosRef; }
   FmIsPositionedBase* getCGRotRef() const { return myCGRotRef; }

--- a/vpmDB/FmSMJointBase.H
+++ b/vpmDB/FmSMJointBase.H
@@ -42,8 +42,8 @@ public:
 
   bool isMasterMovedAlong() const { return IAmMovingMasterTriadAlong.getValue(); }
   bool isSlaveMovedAlong()  const { return IAmMovingSlaveTriadAlong.getValue(); }
-  void setMasterMovedAlong(bool isMovedAlong) { IAmMovingMasterTriadAlong = isMovedAlong; }
-  void setSlaveMovedAlong( bool isMovedAlong) { IAmMovingSlaveTriadAlong  = isMovedAlong; }
+  bool setMasterMovedAlong(bool onOff) { return IAmMovingMasterTriadAlong.setValue(onOff); }
+  bool setSlaveMovedAlong(bool onOff)  { return IAmMovingSlaveTriadAlong.setValue(onOff); }
 
   virtual FaVec3 getTransJointVariables() const;
   virtual FaVec3 getRotJointVariables() const;


### PR DESCRIPTION
For the convenience, they should return true if the value assigned is different than the current value and otherwise false. This also includes two methods in the class FFa3DLocation through the sub-module PR openfedem/fedem-foundation#29