### PR TITLE
Fix install() statement such that the so-files are placed in bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ target_link_libraries ( ${LIB_ID} vpmDB )
 
 install ( TARGETS ${LIB_ID}
           RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
-          LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib" )
+          LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" )
 
 
 if ( BUILD_TESTS )

--- a/chainShape/CMakeLists.txt
+++ b/chainShape/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries ( ${LIB_ID} LINK_PRIVATE Minpack )
 
 install ( TARGETS ${LIB_ID}
           RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
-          LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib" )
+          LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" )


### PR DESCRIPTION
Changing LIBRARY destination which also applies to the shared object libraries (so-files) on Linux.