### PR TITLE
Override FmMathFuncBase::interactiveErase() to erase the FmEngine object...

### DIFF
--- a/test/test_FedemDB.C
+++ b/test/test_FedemDB.C
@@ -14,7 +14,7 @@
 
 extern "C" {
   void FmInit(const char* = NULL, const char* = NULL);
-  void FmNew (const char* = NULL);
+  void FmNew (const char* = NULL, const char* = NULL);
   bool FmOpen(const char* = NULL);
   bool FmSave(const char* = NULL);
   void FmClose(bool = true);

--- a/vpmDB/FmMathFuncBase.H
+++ b/vpmDB/FmMathFuncBase.H
@@ -70,6 +70,8 @@ public:
   virtual bool hasSmartPoints() const;
   virtual bool isSurfaceFunc() const { return false; }
 
+  virtual bool interactiveErase();
+
   virtual int printSolverEntry(FILE* fp);
 
   virtual const char* getFunctionFsiName() const;


### PR DESCRIPTION
...that owns this function when the function use is DRIVE_FILE. This fixes openfedem/fedem-gui#94.
Use a lambda in `FmMathFuncBase::resolveAfterRead()` to avoid duplicated code.
Reduce scope of some temporaries using new if-syntax.