### PR TITLE
Fix unit test for solver input file generation

### DIFF
--- a/test/test_FedemDB.C
+++ b/test/test_FedemDB.C
@@ -23,8 +23,7 @@ extern "C" {
   bool FmAddMass(int, int, const double*, int = 0);
   int  FmCreatePart(const char*, int, int*);
   int  FmCreateJoint(const char*, int, int, int*, int);
-  bool FmSolve(const char*, bool = true,
-               const char* = NULL, const char* = NULL);
+  bool FmSolve(char*, bool = true, const char* = NULL, const char* = NULL);
 }
 
 static std::string srcdir; //!< Full path of the source directory of this test
@@ -42,9 +41,8 @@ int loadTest (const char* fmmFile)
   if (!FmOpen(oldFmm.c_str())) return 1;
   if (!FmSave(newFmm.c_str())) return 2;
   // Write solver input and save updated model
-  std::string newRDB = newFmm.substr(0,newFmm.find_last_of(".")) + "_RDB";
-  if (!FmSolve(newRDB.c_str())) return 3;
-  return FmSave() ? 0 : 4;
+  char newRDB[512];
+  return FmSolve(newRDB) ? (FmSave() ? 0 : 4) : 3;
 }
 
 /*!
@@ -139,16 +137,19 @@ TEST_P(TestCase,SolverRDB)
 {
   ASSERT_FALSE(srcdir.empty());
 
-  // GetParam() will be substituted with the actual file name.
+  // GetParam() will be substituted with the actual file name
   std::string fmmFile = srcdir + GetParam();
+  std::cout <<"\n   * Opening "<< fmmFile;
 
   // Open the model and save to current working directory
   std::string newFmm = fmmFile.substr(fmmFile.find_last_of("/\\")+1);
   ASSERT_TRUE(FmOpen(fmmFile.c_str()));
   ASSERT_TRUE(FmSave(newFmm.c_str()));
+
   // Write solver input and save updated model
-  std::string newRDB = newFmm.substr(0,newFmm.find_last_of(".")) + "_RDB";
-  ASSERT_TRUE(FmSolve(newRDB.c_str()));
+  char newRDB[512];
+  ASSERT_TRUE(FmSolve(newRDB));
+  std::cout <<"   * Solver input files written to "<< newRDB << std::endl;
   ASSERT_TRUE(FmSave());
 }
 

--- a/vpmDB/FmBase.H
+++ b/vpmDB/FmBase.H
@@ -19,7 +19,6 @@
 
 #include "vpmDB/FmArray.H"
 
-#include "FFaLib/FFaContainers/FFaByteArray.H"
 #include "FFaLib/FFaContainers/FFaReference.H"
 #include "FFaLib/FFaContainers/FFaField.H"
 #include "FFaLib/FFaContainers/FFaFieldContainer.H"

--- a/vpmDB/FmFileSys.C
+++ b/vpmDB/FmFileSys.C
@@ -422,7 +422,7 @@ int FmFileSys::removeDir(const std::string& dirName, bool removeFiles)
   if (ndel < 0) return ndel;
 
 #if FT_HAS_QT > 4
-  ret = dir.rmdir(dirName.c_str()) ? ndel : -1;
+  ret = dir.rmdir(dir.absolutePath()) ? ndel : -1;
 #elif defined(FT_HAS_QT)
   ret = dir.rmdir(".") ? ndel : -1;
 #else

--- a/vpmDB/FmLink.C
+++ b/vpmDB/FmLink.C
@@ -65,7 +65,6 @@ FmLink::FmLink(const FaVec3& globalPos)
 
   FFA_FIELD_DEFAULT_INIT(visDataFile,              "VISUALIZATION_FILE");
   FFA_FIELD_DEFAULT_INIT(visDataFileUnitConverter, "ORIGINAL_VISDATA_FILE_CONVERSION");
-  FFA_FIELD_DEFAULT_INIT(cadMainComponentId,       "CAD_MAIN_COMPONENT_ID");
   FFA_FIELD_DEFAULT_INIT(baseCadFileName,          "BASE_CAD_FILE");
 
   FFA_FIELD_INIT(alpha1, 0.0, "MASS_PROP_DAMP");

--- a/vpmDB/FmLink.H
+++ b/vpmDB/FmLink.H
@@ -9,7 +9,6 @@
 #define FM_LINK_H
 
 #include "FFaLib/FFaAlgebra/FFaUnitCalculator.H"
-#include "FFaLib/FFaContainers/FFaByteArray.H"
 #include "FFaLib/FFaString/FFaEnum.H"
 
 #include "vpmDB/FmColor.H"
@@ -20,12 +19,6 @@ template<>
 inline bool FFaField<FFaUnitCalculator>::isPrintable() const
 {
   return !this->isDefault();
-}
-
-template<>
-inline bool FFaField<FFaByteArray>::isPrintable() const
-{
-  return !myData.empty();
 }
 
 
@@ -179,9 +172,6 @@ public:
   FFaField<FFaUnitCalculator> visDataFileUnitConverter;
   //! File that stores internal CAD data
   FFaField<std::string>       baseCadFileName;
-  //! Id used to look up this link in the CAD system
-  FFaField<FFaByteArray>      cadMainComponentId;
-
 
   // Structural damping properties
   FFaField<double> alpha1; //!< Mass proportional damping


### PR DESCRIPTION
Caused a crash on Windows, although it passed on Linux.
Also remove an unused and obsolete field in FmLink and thereby eliminating the use of FFaByteArray,
which is removed in the fedem-foundation submodule.