### PR TITLE
Replace static classes FmDB and FmFuncAdmin by namespaces

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           repository: openfedem/fedem-solvers
           fileName: 'fedempy-*.tar.gz'
-          latest: true
+          tag: fedempy-8.1.2
 
       - name: Configure pFUnit-3
         run: >

--- a/assemblyCreators/jacketCreator.C
+++ b/assemblyCreators/jacketCreator.C
@@ -404,7 +404,7 @@ void FWP::createJacket (const FFlLinkHandler* jl, const std::string& name,
   }
 
   if (FmDB::hasObjectsOfType(FmLink::getClassTypeID(),jacket->getHeadMap()))
-    FmDB::displayAll(*jacket->getHeadMap());
+    FmDB::displayAll(jacket->getHeadMap());
   else
   {
     FFaMsg::list(" ==> Empty jacket assembly, deleted.\n",true);

--- a/vpmDB/FmAssemblyBase.C
+++ b/vpmDB/FmAssemblyBase.C
@@ -43,7 +43,7 @@ void FmAssemblyBase::setLocalCS(const FaMat34& cs, bool updateLoc)
   if (updateLoc)
     this->updateLocation();
 
-  FmDB::displayAll(*this->getHeadMap());
+  FmDB::displayAll(this->getHeadMap());
 }
 
 

--- a/vpmDB/FmBase.C
+++ b/vpmDB/FmBase.C
@@ -326,17 +326,9 @@ bool FmBase::localParse(const char* keyWord, std::istream& activeStatement,
                         FmBase* obj)
 {
   if (!obj->readField(keyWord,activeStatement))
-  {
-    std::string msg(keyWord);
-    msg += " is not a defined fmm-file keyword for ";
-    msg += std::string(obj->getUITypeName()) + "s";
-    std::map<std::string,int>::iterator it = FmDB::unknownKeywords.find(msg);
-    if (it == FmDB::unknownKeywords.end())
-      FmDB::unknownKeywords[msg] = 1;
-    else
-      ++it->second;
-  }
-  else if (strcmp(keyWord,"PARENT_ASSEMBLY") == 0 && FmSubAssembly::old2newAssID.first > 0)
+    FmDB::unknownKeyword(keyWord,obj);
+  else if (strcmp(keyWord,"PARENT_ASSEMBLY") == 0 &&
+           FmSubAssembly::old2newAssID.first > 0)
     if (obj->myParentAssembly.getRefID() == FmSubAssembly::old2newAssID.first)
       obj->myParentAssembly.setRef(FmSubAssembly::old2newAssID.second,
                                    obj->myParentAssembly.getRefTypeID());

--- a/vpmDB/FmBladeProperty.C
+++ b/vpmDB/FmBladeProperty.C
@@ -365,7 +365,7 @@ std::ostream& FmBladeDesign::writeFMF(std::ostream& os)
   this->writeFields(os);
   os <<"}\n\n";
 
-  FmDB::reportMembers(os,*this->getHeadMap());
+  FmDB::reportMembers(os,this->getHeadMap());
 
   return os;
 }
@@ -439,7 +439,7 @@ bool FmBladeDesign::writeToFMM(const std::string& fileName) const
   this->writeFields(os);
   os <<"}\n\n";
 
-  FmDB::reportMembers(os,*this->getHeadMap());
+  FmDB::reportMembers(os,this->getHeadMap());
 
   os <<"END {FEDEMMODELFILE}\n";
 

--- a/vpmDB/FmDB.H
+++ b/vpmDB/FmDB.H
@@ -75,218 +75,177 @@ class FaMat34;
 class FaVec3;
 
 
-class FmDB
+namespace FmDB
 {
-  typedef std::map<int,FmRingStart*> FmHeadMap;
+  using FmHeadMap = std::map<int,FmRingStart*>;
 
-public:
-  static void init();
-  static void removeInstances();
+  void init();
+  void removeInstances();
 
-  static void initHeadMap(FmHeadMap& headMap, FmFuncTree*& funcTree);
-  static void sortHeadMap(const FmHeadMap& headMap, FmHeadMap& sortedHeadMap,
-                          bool reverse = false);
+  void initHeadMap(FmHeadMap& headMap, FmFuncTree*& funcTree);
+  void sortHeadMap(const FmHeadMap& headMap, FmHeadMap& sortedHeadMap,
+                   bool reverse = false);
 
-  static FmModelMemberBase* createObject(int classTypeId);
+  FmModelMemberBase* createObject(int classTypeId);
 
-  static FmMechanism* newMechanism();
+  FmMechanism* newMechanism();
 
   // Head object return
-  static FmRingStart* getHead(int classTypeID);
-  static FmRingStart* getHead(int classTypeID, const std::vector<int>& assemblyID,
-                              const FmHeadMap* root = NULL);
-  static FmRingStart* getHead(int classTypeID, const FmHeadMap* headMap);
+  FmRingStart* getHead(int classTypeID);
+  FmRingStart* getHead(int classTypeID, const std::vector<int>& assemblyID,
+                       const FmHeadMap* root = NULL);
 
   // Search for ID
-  static bool findIDrange(const FmBase* obj, int& fromID, int& toID);
-  static FmBase* findID(int type, int IDnr,
-			const std::vector<int>& assemblyID = std::vector<int>());
-  static FmBase* findID(const std::string& type, int IDnr,
-			const std::vector<int>& assemblyID = std::vector<int>());
+  bool findIDrange(const FmBase* obj, int& fromID, int& toID);
+  FmBase* findID(int type, int IDnr, const std::vector<int>& assemblyID = {});
+  FmBase* findID(const std::string& type, int IDnr,
+                 const std::vector<int>& assemblyID = {});
 
   // Collects all pathnames in the model
-  static void getAllPaths(std::vector<FFaField<std::string>*>& allPathNames,
-                          const FmSubAssembly* subAss = NULL);
+  void getAllPaths(std::vector<FFaField<std::string>*>& allPathNames,
+                   const FmSubAssembly* subAss = NULL);
   // Corrects all relative pathnames to external input files in the model
   // when moving it to a different directory (Save As...)
-  static void translateRelativePaths(const std::string& oldModelPath,
-				     const std::string& newModelPath,
-				     const FmSubAssembly* subAss = NULL);
+  void translateRelativePaths(const std::string& oldModelPath,
+                              const std::string& newModelPath,
+                              const FmSubAssembly* subAss = NULL);
 
   // Compresses the model by removing all inactive joint dof objects
-  static bool purgeJointComponents();
+  bool purgeJointComponents();
 
-  static bool updateModelVersionOnSave(bool warnOnNewVersion);
+  bool updateModelVersionOnSave(bool warnOnNewVersion);
 
-  static bool reportAll(std::ostream& os = std::cout, bool writeMetaData = true,
-                        const FmHeadMap& headMap = ourHeadMap,
-                        const char* addMetaData = NULL);
-  static void reportMembers(std::ostream& os, const FmHeadMap& headMap);
+  bool reportAll(std::ostream& os = std::cout, bool writeMetaData = true,
+                 const FmHeadMap* headMap = NULL, const char* metaData = NULL);
+  void reportMembers(std::ostream& os, const FmHeadMap* headMap);
 
-  static void displayAll(const FmHeadMap& headMap = ourHeadMap);
-  static bool eraseAll(bool showProgress = false);
+  void displayAll(const FmHeadMap* headMap = NULL);
+  bool eraseAll(bool showProgress = false);
 
-  static void forAllInDB(FFaDynCB2<bool&,FmBase*>& toBeCalled4EachHead,
-                         FFaDynCB1<FmBase*>& toBeCalled4Each,
-                         const FmHeadMap* root = &ourHeadMap);
+  void forAllInDB(FFaDynCB2<bool&,FmBase*>& toBeCalled4EachHead,
+                  FFaDynCB1<FmBase*>& toBeCalled4Each,
+                  const FmHeadMap* root = NULL);
 
-  static int getObjectCount(int type, const FmHeadMap* root = &ourHeadMap);
+  int getObjectCount(int type, const FmHeadMap* root = NULL);
 
-  // Vector to fill up, map with TypeID and a bool saying
-  // if we want/don't want objects of type TypeID
-  static void getTypeQuery(std::vector<FmModelMemberBase*>& toBeFilled,
-                           const std::map<int,bool>& query);
+  void getQuery(std::vector<FmModelMemberBase*>& toBeFilled, FmQuery* query);
 
-  static void getQuery(std::vector<FmModelMemberBase*>& toBeFilled, FmQuery* query);
+  bool getAllOfType(std::vector<FmModelMemberBase*>& toBeFilled, int typeID,
+                    const FmSubAssembly* subAss = NULL, const char* tag = NULL);
 
-  static bool getAllOfType(std::vector<FmModelMemberBase*>& toBeFilled, int typeID,
-                           const FmSubAssembly* subAss = NULL, const char* tag = NULL);
+  bool hasObjectsOfType(int typeID, const FmHeadMap* root = NULL);
 
-  static bool hasObjectsOfType(int typeID, const FmHeadMap* root = &ourHeadMap);
+  void getFEParts(std::vector<FmPart*>& toFill, bool reverseOrder = false);
+  void getUnsavedParts(std::vector<FmPart*>& toFill);
+  void getAllParts(std::vector<FmPart*>& toFill,
+                   const FmSubAssembly* subAss = NULL,
+                   bool thisLevelOnly = false);
+  void getAllBeams(std::vector<FmBeam*>& toFill,
+                   const FmSubAssembly* subAss = NULL,
+                   bool thisLevelOnly = false);
+  void getAllLinks(std::vector<FmLink*>& toFill,
+                   const FmSubAssembly* subAss = NULL,
+                   bool thisLevelOnly = false);
+  void getAllTriads(std::vector<FmTriad*>& toFill,
+                    const FmSubAssembly* subAss = NULL,
+                    bool thisLevelOnly = false);
+  void getAllFunctions(std::vector<FmMathFuncBase*>& toFill,
+                       const FmSubAssembly* subAss = NULL,
+                       bool thisLevelOnly = false);
 
-  static void getFEParts(std::vector<FmPart*>& toFill, bool reverseOrder = false);
-  static void getUnsavedParts(std::vector<FmPart*>& toFill);
-  static void getAllParts(std::vector<FmPart*>& toFill,
-			  const FmSubAssembly* subAss = NULL,
-			  bool thisLevelOnly = false);
-  static void getAllBeams(std::vector<FmBeam*>& toFill,
-			  const FmSubAssembly* subAss = NULL,
-			  bool thisLevelOnly = false);
-  static void getAllLinks(std::vector<FmLink*>& toFill,
-			  const FmSubAssembly* subAss = NULL,
-			  bool thisLevelOnly = false);
-  static void getAllTriads(std::vector<FmTriad*>& toFill,
-			   const FmSubAssembly* subAss = NULL,
-			   bool thisLevelOnly = false);
-  static void getAllFunctions(std::vector<FmMathFuncBase*>& toFill,
-			      const FmSubAssembly* subAss = NULL,
-			      bool thisLevelOnly = false);
+  void getAllSplines(std::vector<FmfSpline*>& toFill);
+  void getAllMultiVarFuncs(std::vector<FmfMultiVarBase*>& toFill);
+  void getAllDeviceFunctions(std::vector<FmfDeviceFunction*>& toFill);
+  void getAllJoints(std::vector<FmJointBase*>& toFill);
+  void getAllHPs(std::vector<FmHPBase*>& toFill);
 
-  static void getAllSplines(std::vector<FmfSpline*>& toFill);
-  static void getAllMultiVarFuncs(std::vector<FmfMultiVarBase*>& toFill);
-  static void getAllDeviceFunctions(std::vector<FmfDeviceFunction*>& toFill);
-  static void getAllJoints(std::vector<FmJointBase*>& toFill);
-  static void getAllHPs(std::vector<FmHPBase*>& toFill);
+  void getAllGears(std::vector<FmGear*>& toFill);
+  void getAllRackPinions(std::vector<FmRackPinion*>& toFill);
+  void getAllCylJoints(std::vector<FmCylJoint*>& toFill);
+  void getAllCamJoints(std::vector<FmCamJoint*>& toFill);
 
-  static void getAllGears(std::vector<FmGear*>& toFill);
-  static void getAllRackPinions(std::vector<FmRackPinion*>& toFill);
-  static void getAllCylJoints(std::vector<FmCylJoint*>& toFill);
-  static void getAllCamJoints(std::vector<FmCamJoint*>& toFill);
+  void getAllRevJoints(std::vector<FmRevJoint*>& toFill);
+  void getAllBallJoints(std::vector<FmBallJoint*>& toFill);
+  void getAllFreeJoints(std::vector<FmFreeJoint*>& toFill);
+  void getAllRigidJoints(std::vector<FmRigidJoint*>& toFill);
+  void getAllPrismJoints(std::vector<FmPrismJoint*>& toFill);
+  void getAllControlLines(std::vector<FmCtrlLine*>& toFill);
+  void getAllLoads(std::vector<FmLoad*>& toFill);
 
-  static void getAllRevJoints(std::vector<FmRevJoint*>& toFill);
-  static void getAllBallJoints(std::vector<FmBallJoint*>& toFill);
-  static void getAllFreeJoints(std::vector<FmFreeJoint*>& toFill);
-  static void getAllRigidJoints(std::vector<FmRigidJoint*>& toFill);
-  static void getAllPrismJoints(std::vector<FmPrismJoint*>& toFill);
-  static void getAllControlLines(std::vector<FmCtrlLine*>& toFill);
-  static void getAllLoads(std::vector<FmLoad*>& toFill);
+  void getAllAxialSprings(std::vector<FmAxialSpring*>& toFill);
+  void getAllJointSprings(std::vector<FmJointSpring*>& toFill);
+  void getAllSpringChars(std::vector<FmSpringChar*>& toFill);
+  void getAllAxialDampers(std::vector<FmAxialDamper*>& toFill);
+  void getAllJointDampers(std::vector<FmJointDamper*>& toFill);
 
-  static void getAllAxialSprings(std::vector<FmAxialSpring*>& toFill);
-  static void getAllJointSprings(std::vector<FmJointSpring*>& toFill);
-  static void getAllSpringChars(std::vector<FmSpringChar*>& toFill);
-  static void getAllAxialDampers(std::vector<FmAxialDamper*>& toFill);
-  static void getAllJointDampers(std::vector<FmJointDamper*>& toFill);
+  void getAllSensors(std::vector<FmSensorBase*>& toFill);
+  void getAllEngines(std::vector<FmEngine*>& engines);
+  void getAllExternalCtrlSys(std::vector<FmExternalCtrlSys*>& toFill);
+  void getAllRefPlanes(std::vector<FmRefPlane*>& toFill);
+  void getAllStickers(std::vector<FmSticker*>& toFill);
 
-  static void getAllSensors(std::vector<FmSensorBase*>& toFill);
-  static void getAllEngines(std::vector<FmEngine*>& engines);
-  static void getAllExternalCtrlSys(std::vector<FmExternalCtrlSys*>& toFill);
-  static void getAllRefPlanes(std::vector<FmRefPlane*>& toFill);
-  static void getAllStickers(std::vector<FmSticker*>& toFill);
+  void getAllControlOutput(std::vector<FmcOutput*>& toFill);
+  void getAllControlInput(std::vector<FmcInput*>& toFill);
+  void getAllControlElements(std::vector<FmCtrlInputElementBase*>& toFill);
 
-  static void getAllControlOutput(std::vector<FmcOutput*>& toFill);
-  static void getAllControlInput(std::vector<FmcInput*>& toFill);
-  static void getAllControlElements(std::vector<FmCtrlInputElementBase*>& toFill);
+  void getAllBladeDesigns(std::vector<FmBladeDesign*>& toFill);
+  void getAllSimulationEvents(std::vector<FmSimulationEvent*>& toFill,
+                              bool reverseOrder = false);
 
-  static void getAllBladeDesigns(std::vector<FmBladeDesign*>& toFill);
-  static void getAllSimulationEvents(std::vector<FmSimulationEvent*>& toFill,
-                                     bool reverseOrder = false);
+  bool readAll(const std::string& name, char ignoreFileVersion = 0);
+  int  readFMF(std::istream& is);
 
-  static bool readAll(const std::string& name, char ignoreFileVersion = 0);
-  static int  readFMF(std::istream& is);
+  void unknownKeyword(const char* keyWord, const FmBase* obj);
 
-  static FmGlobalViewSettings* getActiveViewSettings(bool createIfNone = true);
-  static FmAnalysis* getActiveAnalysis(bool createIfNone = true);
-  static FmModesOptions* getModesOptions(bool createIfNone = true);
-  static FmGageOptions* getGageOptions(bool createIfNone = true);
-  static FmFppOptions* getFppOptions(bool createIfNone = true);
-  static FmModelExpOptions* getModelExportOptions(bool createIfNone = true);
-  static FmVesselMotion* getActiveRAO();
+  FmGlobalViewSettings* getActiveViewSettings(bool createIfNone = true);
+  FmAnalysis* getActiveAnalysis(bool createIfNone = true);
+  FmModesOptions* getModesOptions(bool createIfNone = true);
+  FmGageOptions* getGageOptions(bool createIfNone = true);
+  FmFppOptions* getFppOptions(bool createIfNone = true);
+  FmModelExpOptions* getModelExportOptions(bool createIfNone = true);
+  FmVesselMotion* getActiveRAO();
 
-  static double getPositionTolerance();
-  static double getParallelTolerance() { return parallelTol; }
-  static void setParallelTolerance(double eps) { parallelTol = eps; }
-  static const FaVec3& getGrav();
-  static void drawGVector();
+  double getPositionTolerance();
+  double getParallelTolerance();
+  void setParallelTolerance(double eps);
+  const FaVec3& getGrav();
+  void drawGVector();
 
-  static FaMat34 getSeaCS();
-  static bool    useSeaCS();
-  static void    drawSea();
+  FaMat34 getSeaCS();
+  bool    useSeaCS();
+  void    drawSea();
 
-  static FmLink* getEarthLink() { return itsEarthLink; }
-  static FmSensorBase* getTimeSensor(bool createIfNone = true);
-  static FmSeaState* getSeaStateObject(bool createIfNone = true);
-  static FmAirState* getAirStateObject(bool createIfNone = true);
-  static FmMechanism* getMechanismObject(bool createIfNone = true);
-  static FmTurbine* getTurbineObject(int ID = 0);
+  FmLink* getEarthLink();
+  FmSensorBase* getTimeSensor(bool createIfNone = true);
+  FmSeaState* getSeaStateObject(bool createIfNone = true);
+  FmAirState* getAirStateObject(bool createIfNone = true);
+  FmMechanism* getMechanismObject(bool createIfNone = true);
+  FmTurbine* getTurbineObject(int ID = 0);
 
-  static void emergencyExitSave();
+  void emergencyExitSave();
 
-  static void eraseAllStickers();
-  static void eraseAllControlObjects();
+  void eraseAllStickers();
+  void eraseAllControlObjects();
 
-  static bool hasObjects(int typeID, const FmHeadMap* root = &ourHeadMap);
+  bool hasObjects(int typeID, const FmHeadMap* root = NULL);
 
-  static const FFaVersionNumber& getModelFileVer() { return ourModelFileVersion; }
+  const FFaVersionNumber& getModelFileVer();
 
-  static const FmHeadMap* getHeadMap(const FmSubAssembly* subAss = NULL);
-  static const FmHeadMap* getHeadMap(const std::vector<int>& assemblyID,
-                                     const FmHeadMap* root = &ourHeadMap);
+  const FmHeadMap* getHeadMap(const FmSubAssembly* subAss = NULL);
 
-  static FmSubAssembly* getSubAssembly(const std::vector<int>& assemblyID);
+  FmSubAssembly* getSubAssembly(const std::vector<int>& assemblyID);
 
   // Finds the model member based on baseID
-  static FmModelMemberBase* findObject(int baseID);
-  static bool insertInBaseIDMap(FmModelMemberBase* pt);
-  static void removeFromBaseIDMap(FmModelMemberBase* pt);
+  FmModelMemberBase* findObject(int baseID);
+  bool insertInBaseIDMap(FmModelMemberBase* pt);
+  void removeFromBaseIDMap(FmModelMemberBase* pt);
 
   // Returns next free baseID
-  static int getFreeBaseID();
+  int getFreeBaseID();
 
   // Convenience methods for resolving
-  static void resolveObject(FmBase* obj);
-  static void initAfterResolveObject(FmBase* obj);
-
-private:
-  static FmHeadMap                        ourHeadMap;
-  static std::map<int,FmModelMemberBase*> ourBaseIDMap;
-
-  static double parallelTol;
-
-  static FmFuncTree* itsFuncTree;
-  static FmLink*     itsEarthLink;
-
-  static FFaVersionNumber ourCurrentFedemVersion;
-  static FFaVersionNumber ourModelFileVersion;
-  static int              ourSaveNr;
-
-public:
-  static std::map<std::string,int> unknownKeywords;
-
-private:
-  static bool appendAllOfType(std::vector<FmModelMemberBase*>& toBeFilled, int typeID,
-                              const std::vector<int>& butNotOfTypes = std::vector<int>(),
-                              const std::string& tagged = "");
-
-  static bool appendAllOfType(std::vector<FmModelMemberBase*>& toBeFilled, int typeID,
-                              const std::vector<int>& butNotOfTypes,
-                              const std::string& tagged, const FmHeadMap* root);
-
-  static const FmHeadMap* getHeadMap(const FmHeadMap* root,
-				     std::vector<int>::const_iterator it,
-				     std::vector<int>::const_iterator end,
-				     int parentAssemblyID = 0);
-
-  static void displayMembers(int typeID, const FmHeadMap* root);
-};
+  void resolveObject(FmBase* obj);
+  void initAfterResolveObject(FmBase* obj);
+}
 
 #endif

--- a/vpmDB/FmFuncAdmin.C
+++ b/vpmDB/FmFuncAdmin.C
@@ -6,102 +6,117 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <algorithm>
+#include <map>
 
 #include "FFaFunctionLib/FFaUserFuncPlugin.H"
 
 #include "vpmDB/FmAllFunctionHeaders.H"
 #include "vpmDB/FmFuncAdmin.H"
 
-FuncInfoMap FmFuncAdmin::itsFuncInfoTable;
-std::vector<int> FmFuncAdmin::allowableSprDmpFuncs;
 
-static int numClassTypes = 0;
-
-
-void FmFuncAdmin::init()
+namespace
 {
-  itsFuncInfoTable[NONE]                = FmFuncTypeInfo("   1:1");
+  std::map<int,FmFuncTypeInfo> itsFuncInfoTable;
 
-  itsFuncInfoTable[GENERAL_HEADING]     = FmFuncTypeInfo("-- General Functions --");
+  int numClassTypes = 0;
 
-  itsFuncInfoTable[LIN_VAR]             = FmFuncTypeInfo("    Poly line", FmfLinVar::getClassTypeID());
-  itsFuncInfoTable[DEVICE]              = FmFuncTypeInfo("    Poly line from file", FmfDeviceFunction::getClassTypeID());
-  itsFuncInfoTable[SPLINE]              = FmFuncTypeInfo("    Spline", FmfSpline::getClassTypeID());
-  itsFuncInfoTable[MATH_EXPRESSION]     = FmFuncTypeInfo("    Math expression", FmfMathExpr::getClassTypeID());
-
-  itsFuncInfoTable[SIMPLE_HEADING]      = FmFuncTypeInfo("-- Simple Functions --");
-
-  itsFuncInfoTable[CONSTANT]            = FmFuncTypeInfo("    Constant", FmfConstant::getClassTypeID());
-  itsFuncInfoTable[SCALE]               = FmFuncTypeInfo("    Linear", FmfScale::getClassTypeID());
-  itsFuncInfoTable[RAMP]                = FmFuncTypeInfo("    Ramp", FmfRamp::getClassTypeID());
-  itsFuncInfoTable[LIM_RAMP]            = FmFuncTypeInfo("    Limited ramp", FmfLimRamp::getClassTypeID());
-  itsFuncInfoTable[STEP]                = FmFuncTypeInfo("    Step", FmfStep::getClassTypeID());
-  itsFuncInfoTable[DIRAC_PULS]          = FmFuncTypeInfo("    Pulse", FmfDiracPuls::getClassTypeID());
-
-  itsFuncInfoTable[PERIODIC_HEADING]    = FmFuncTypeInfo("-- Periodic Functions --");
-
-  itsFuncInfoTable[SINUSOIDAL]          = FmFuncTypeInfo("    Sine", FmfSinusoidal::getClassTypeID());
-  itsFuncInfoTable[COMPL_SINUS]         = FmFuncTypeInfo("    Combined sine", FmfComplSinus::getClassTypeID());
-  itsFuncInfoTable[DELAYED_COMPL_SINUS] = FmFuncTypeInfo("    Delayed combined sine", FmfDelayedComplSinus::getClassTypeID());
-  itsFuncInfoTable[WAVE_SINUS]          = FmFuncTypeInfo("    Wave sine", FmfWaveSinus::getClassTypeID());
-  itsFuncInfoTable[WAVE_SPECTRUM]       = FmFuncTypeInfo("    JONSWAP sea wave spectrum", FmfWaveSpectrum::getClassTypeID());
-  itsFuncInfoTable[FILE_SPECTRUM]       = FmFuncTypeInfo("    User defined wave spectrum", FmfDeviceFunction::getClassTypeID());
-  itsFuncInfoTable[SQUARE_PULS]         = FmFuncTypeInfo("    Periodic square pulse", FmfSquarePuls::getClassTypeID());
-
-  itsFuncInfoTable[SPECIAL_HEADING]     = FmFuncTypeInfo("-- Special Functions --");
-
-  itsFuncInfoTable[SMOOTH_TRAJ]         = FmFuncTypeInfo("    Smooth trajectory", FmfSmoothTraj::getClassTypeID());
-  itsFuncInfoTable[LIN_VEL_VAR]         = FmFuncTypeInfo("    Linear derivative", FmfLinVelVar::getClassTypeID());
-  itsFuncInfoTable[EXTERNAL]            = FmFuncTypeInfo("    External function", FmfExternalFunction::getClassTypeID());
-  itsFuncInfoTable[REFERENCE]           = FmFuncTypeInfo("    Refer to other function");
-
-  const int maxUF = 400;
-  int funcId[maxUF];
-  int nUserFuncs = FFaUserFuncPlugin::instance()->getFuncs(maxUF,funcId);
-  if (nUserFuncs > 0)
+  void initFuncInfoTable()
   {
-    numClassTypes = FFaTypeCheck::getNewTypeID(NULL);
+    using namespace FmFuncAdmin;
 
-    std::string funcName(64,' ');
-    const char* fName = funcName.c_str()+4;
-    itsFuncInfoTable[USER_HEADING] = FmFuncTypeInfo("-- User-defined Functions --");
-    for (int i = 1; i <= nUserFuncs; i++)
-      if (FFaUserFuncPlugin::instance()->getFuncName(funcId[i-1],60,const_cast<char*>(fName)) > 0)
-	itsFuncInfoTable[USER_HEADING+i] = FmFuncTypeInfo(funcName,numClassTypes+funcId[i-1]);
+    itsFuncInfoTable[NONE] = "   1:1";
+
+    itsFuncInfoTable[GENERAL_HEADING] = "-- General Functions --";
+
+    itsFuncInfoTable[LIN_VAR]         = FmFuncTypeInfo("    Poly line", FmfLinVar::getClassTypeID());
+    itsFuncInfoTable[DEVICE]          = FmFuncTypeInfo("    Poly line from file", FmfDeviceFunction::getClassTypeID());
+    itsFuncInfoTable[SPLINE]          = FmFuncTypeInfo("    Spline", FmfSpline::getClassTypeID());
+    itsFuncInfoTable[MATH_EXPRESSION] = FmFuncTypeInfo("    Math expression", FmfMathExpr::getClassTypeID());
+
+    itsFuncInfoTable[SIMPLE_HEADING] = "-- Simple Functions --";
+
+    itsFuncInfoTable[CONSTANT]   = FmFuncTypeInfo("    Constant", FmfConstant::getClassTypeID());
+    itsFuncInfoTable[SCALE]      = FmFuncTypeInfo("    Linear", FmfScale::getClassTypeID());
+    itsFuncInfoTable[RAMP]       = FmFuncTypeInfo("    Ramp", FmfRamp::getClassTypeID());
+    itsFuncInfoTable[LIM_RAMP]   = FmFuncTypeInfo("    Limited ramp", FmfLimRamp::getClassTypeID());
+    itsFuncInfoTable[STEP]       = FmFuncTypeInfo("    Step", FmfStep::getClassTypeID());
+    itsFuncInfoTable[DIRAC_PULS] = FmFuncTypeInfo("    Pulse", FmfDiracPuls::getClassTypeID());
+
+    itsFuncInfoTable[PERIODIC_HEADING] = "-- Periodic Functions --";
+
+    itsFuncInfoTable[SINUSOIDAL]          = FmFuncTypeInfo("    Sine", FmfSinusoidal::getClassTypeID());
+    itsFuncInfoTable[COMPL_SINUS]         = FmFuncTypeInfo("    Combined sine", FmfComplSinus::getClassTypeID());
+    itsFuncInfoTable[DELAYED_COMPL_SINUS] = FmFuncTypeInfo("    Delayed combined sine", FmfDelayedComplSinus::getClassTypeID());
+    itsFuncInfoTable[WAVE_SINUS]          = FmFuncTypeInfo("    Wave sine", FmfWaveSinus::getClassTypeID());
+    itsFuncInfoTable[WAVE_SPECTRUM]       = FmFuncTypeInfo("    JONSWAP sea wave spectrum", FmfWaveSpectrum::getClassTypeID());
+    itsFuncInfoTable[FILE_SPECTRUM]       = FmFuncTypeInfo("    User defined wave spectrum", FmfDeviceFunction::getClassTypeID());
+    itsFuncInfoTable[SQUARE_PULS]         = FmFuncTypeInfo("    Periodic square pulse", FmfSquarePuls::getClassTypeID());
+
+    itsFuncInfoTable[SPECIAL_HEADING] = "-- Special Functions --";
+
+    itsFuncInfoTable[SMOOTH_TRAJ] = FmFuncTypeInfo("    Smooth trajectory", FmfSmoothTraj::getClassTypeID());
+    itsFuncInfoTable[LIN_VEL_VAR] = FmFuncTypeInfo("    Linear derivative", FmfLinVelVar::getClassTypeID());
+    itsFuncInfoTable[EXTERNAL]    = FmFuncTypeInfo("    External function", FmfExternalFunction::getClassTypeID());
+    itsFuncInfoTable[REFERENCE]   = FmFuncTypeInfo("    Refer to other function");
+
+    const int maxUF = 400;
+    int funcId[maxUF];
+    int nUserFuncs = FFaUserFuncPlugin::instance()->getFuncs(maxUF,funcId);
+    if (nUserFuncs > 0)
+    {
+      numClassTypes = FFaTypeCheck::getNewTypeID(NULL);
+
+      std::string funcName(64,' ');
+      const char* fName = funcName.c_str()+4;
+      itsFuncInfoTable[USER_HEADING] = "-- User-defined Functions --";
+      for (int i = 1; i <= nUserFuncs; i++)
+        if (FFaUserFuncPlugin::instance()->getFuncName(funcId[i-1],60,const_cast<char*>(fName)) > 0)
+          itsFuncInfoTable[USER_HEADING+i] = FmFuncTypeInfo(funcName.c_str(),numClassTypes+funcId[i-1]);
+    }
+
+    for (std::pair<const int,FmFuncTypeInfo>& info : itsFuncInfoTable)
+      info.second.funcMenuEnum = info.first;
+
+    itsFuncInfoTable[WAVE_SINUS].funcMenuEnum = INTERNAL; // Should not appear in Function type menu
   }
+}
 
-  for (FuncInfoMap::iterator it = itsFuncInfoTable.begin(); it != itsFuncInfoTable.end(); it++)
-    it->second.funcMenuEnum = it->first;
 
-  itsFuncInfoTable[WAVE_SINUS].funcMenuEnum = INTERNAL; // Should not appear in Function type menu
+FmFuncTypeInfo::FmFuncTypeInfo(const char* fn, int ft)
+{
+  listName = fn ? fn : "(noname)";
+  funcType = ft;
+  funcMenuEnum = -1;
 }
 
 
 int FmFuncTypeInfo::getFuncType() const
 {
-  return funcType > FFaTypeCheck::getNewTypeID(NULL) ? FmfUserDefined::getClassTypeID() : funcType;
+  if (funcType > FFaTypeCheck::getNewTypeID(NULL))
+    return FmfUserDefined::getClassTypeID();
+
+  return funcType;
+}
+
+
+void FmFuncAdmin::clearInfoTable()
+{
+  itsFuncInfoTable.clear();
 }
 
 
 const std::vector<int>& FmFuncAdmin::getAllowableSprDmpFuncTypes()
 {
-  if (allowableSprDmpFuncs.empty()) {
-    allowableSprDmpFuncs.push_back(FmfConstant::getClassTypeID());
-    allowableSprDmpFuncs.push_back(FmfScale::getClassTypeID());
-    allowableSprDmpFuncs.push_back(FmfRamp::getClassTypeID());
-    allowableSprDmpFuncs.push_back(FmfLimRamp::getClassTypeID());
-    allowableSprDmpFuncs.push_back(FmfLinVar::getClassTypeID());
-    allowableSprDmpFuncs.push_back(FmfDeviceFunction::getClassTypeID());
-  }
+  static std::vector<int> allowableFuncs = {
+    FmfConstant::getClassTypeID(),
+    FmfScale::getClassTypeID(),
+    FmfRamp::getClassTypeID(),
+    FmfLimRamp::getClassTypeID(),
+    FmfLinVar::getClassTypeID(),
+    FmfDeviceFunction::getClassTypeID()
+  };
 
-  return allowableSprDmpFuncs;
-}
-
-
-bool FmFuncAdmin::isAllowableSprDmpFuncType(int type)
-{
-  const std::vector<int>& ftypes = getAllowableSprDmpFuncTypes();
-  return std::find(ftypes.begin(),ftypes.end(),type) != ftypes.end();
+  return allowableFuncs;
 }
 
 
@@ -128,116 +143,95 @@ bool FmFuncAdmin::hasSmartPoints(int type)
 void FmFuncAdmin::getCompatibleFunctionTypes(std::vector<FmFuncTypeInfo>& toFill,
                                              FmMathFuncBase* compatibleFunc)
 {
-  if (itsFuncInfoTable.empty())
-    FmFuncAdmin::init();
-
   toFill.clear();
-  FuncInfoMap::const_iterator it;
+  if (!compatibleFunc)
+    return;
 
-  if (compatibleFunc)
-    switch (compatibleFunc->getFunctionUse())
-      {
-      case FmMathFuncBase::GENERAL:
-	if (compatibleFunc->getTypeID() == FmfWaveSinus::getClassTypeID()) {
-	  // Internal function with predefined type, don't allow type switching
-	  toFill.push_back(itsFuncInfoTable[FmFuncAdmin::WAVE_SINUS]);
-	  return;
-	}
-	break;
+  if (itsFuncInfoTable.empty())
+    initFuncInfoTable();
 
-      case FmMathFuncBase::DRIVE_FILE:
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::DEVICE]);
-	return;
+  using FmFuncInfo = std::pair<const int,FmFuncTypeInfo>;
 
-      case FmMathFuncBase::NONE:
-      case FmMathFuncBase::ROAD_FUNCTION:
-      case FmMathFuncBase::CURR_FUNCTION:
-	for (it = itsFuncInfoTable.begin(); it != itsFuncInfoTable.end(); it++)
-	  if (it->second.funcMenuEnum  > FmFuncAdmin::NONE &&
-	      it->second.funcMenuEnum != FmFuncAdmin::WAVE_SPECTRUM &&
-	      it->second.funcMenuEnum != FmFuncAdmin::FILE_SPECTRUM &&
-	      it->second.funcMenuEnum != FmFuncAdmin::REFERENCE)
-	    toFill.push_back(it->second);
-	return;
+  switch (compatibleFunc->getFunctionUse())
+    {
+    case FmMathFuncBase::GENERAL:
+      // General function, allow all function types,
+      // except for internal ones and wave spectrums
+      if (compatibleFunc->getTypeID() == FmfWaveSinus::getClassTypeID())
+        // Internal function with predefined type, don't allow type switching
+        toFill.push_back(itsFuncInfoTable[FmFuncAdmin::WAVE_SINUS]);
+      else
+        for (const FmFuncInfo& info : itsFuncInfoTable)
+          if (info.second.funcMenuEnum > FmFuncAdmin::UNDEFINED &&
+              info.second.funcMenuEnum != FmFuncAdmin::WAVE_SPECTRUM &&
+              info.second.funcMenuEnum != FmFuncAdmin::FILE_SPECTRUM)
+            toFill.push_back(info.second);
+      return;
 
-      case FmMathFuncBase::WAVE_FUNCTION:
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::SINUSOIDAL]);
-	/* Disabled by kmo 17.10.2012. Only to be consistent with documentation.
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::COMPL_SINUS]);
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::DELAYED_COMPL_SINUS]);
-	*/
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::WAVE_SPECTRUM]);
-	toFill.push_back(itsFuncInfoTable[FmFuncAdmin::FILE_SPECTRUM]);
-	// Check if we have user-defined wave functions
-	for (it = itsFuncInfoTable.begin(); it != itsFuncInfoTable.end(); it++)
-	  if (it->first > FmFuncAdmin::USER_HEADING && it->second.funcType > numClassTypes)
-	  {
-	    int fId = it->second.funcType - numClassTypes;
-	    if (FFaUserFuncPlugin::instance()->getFlag(fId) & 4)
-	      toFill.push_back(it->second);
-	  }
-	return;
+    case FmMathFuncBase::DRIVE_FILE:
+      toFill.push_back(itsFuncInfoTable[FmFuncAdmin::DEVICE]);
+      return;
 
-      default: // Stiffness or Damper function
-	for (it = itsFuncInfoTable.begin(); it != itsFuncInfoTable.end(); it++)
-	  if (isAllowableSprDmpFuncType(it->second.funcType))
-	    if (it->first != FmFuncAdmin::FILE_SPECTRUM)
-	      toFill.push_back(it->second);
-	return;
-      }
+    case FmMathFuncBase::NONE:
+    case FmMathFuncBase::ROAD_FUNCTION:
+    case FmMathFuncBase::CURR_FUNCTION:
+      for (const FmFuncInfo& info : itsFuncInfoTable)
+        if (info.second.funcMenuEnum  > FmFuncAdmin::NONE &&
+            info.second.funcMenuEnum != FmFuncAdmin::WAVE_SPECTRUM &&
+            info.second.funcMenuEnum != FmFuncAdmin::FILE_SPECTRUM &&
+            info.second.funcMenuEnum != FmFuncAdmin::REFERENCE)
+          toFill.push_back(info.second);
+      return;
 
-  // General function, allow all function types,
-  // except for internal ones and wave spectrums
-  for (it = itsFuncInfoTable.begin(); it != itsFuncInfoTable.end(); it++)
-    if (it->second.funcMenuEnum > FmFuncAdmin::UNDEFINED &&
-	it->second.funcMenuEnum != FmFuncAdmin::WAVE_SPECTRUM &&
-	it->second.funcMenuEnum != FmFuncAdmin::FILE_SPECTRUM)
-      toFill.push_back(it->second);
+    case FmMathFuncBase::WAVE_FUNCTION:
+      toFill.push_back(itsFuncInfoTable[FmFuncAdmin::SINUSOIDAL]);
+      toFill.push_back(itsFuncInfoTable[FmFuncAdmin::WAVE_SPECTRUM]);
+      toFill.push_back(itsFuncInfoTable[FmFuncAdmin::FILE_SPECTRUM]);
+      // Check if we have user-defined wave functions
+      for (const FmFuncInfo& info : itsFuncInfoTable)
+        if (info.first > FmFuncAdmin::USER_HEADING &&
+            info.second.funcType > numClassTypes)
+          if (int fId = info.second.funcType - numClassTypes;
+              FFaUserFuncPlugin::instance()->getFlag(fId) & 4)
+            toFill.push_back(info.second);
+      return;
+
+    default: // Stiffness or Damper function
+      break;
+    }
+
+    const std::vector<int>& ftyp = FmFuncAdmin::getAllowableSprDmpFuncTypes();
+    for (const FmFuncInfo& info : itsFuncInfoTable)
+      if (std::find(ftyp.begin(),ftyp.end(),info.second.funcType) != ftyp.end())
+        if (info.first != FmFuncAdmin::FILE_SPECTRUM)
+          toFill.push_back(info.second);
 }
 
 
 FmMathFuncBase* FmFuncAdmin::createFunction(int type)
 {
-  if      (type == FmfLinVar::getClassTypeID())
-    return new FmfLinVar();
-  else if (type == FmfConstant::getClassTypeID())
-    return new FmfConstant();
-  else if (type == FmfSinusoidal::getClassTypeID())
-    return new FmfSinusoidal();
-  else if (type == FmfComplSinus::getClassTypeID())
-    return new FmfComplSinus();
-  else if (type == FmfDelayedComplSinus::getClassTypeID())
-    return new FmfDelayedComplSinus();
-  else if (type == FmfStep::getClassTypeID())
-    return new FmfStep();
-  else if (type == FmfScale::getClassTypeID())
-    return new FmfScale();
-  else if (type == FmfSpline::getClassTypeID())
-    return new FmfSpline();
-  else if (type == FmfRamp::getClassTypeID())
-    return new FmfRamp();
-  else if (type == FmfSquarePuls::getClassTypeID())
-    return new FmfSquarePuls();
-  else if (type == FmfDiracPuls::getClassTypeID())
-    return new FmfDiracPuls();
-  else if (type == FmfLimRamp::getClassTypeID())
-    return new FmfLimRamp();
-  else if (type == FmfSmoothTraj::getClassTypeID())
-    return new FmfSmoothTraj();
-  else if (type == FmfLinVelVar::getClassTypeID())
-    return new FmfLinVelVar();
-  else if (type == FmfDeviceFunction::getClassTypeID())
-    return new FmfDeviceFunction();
-  else if (type == FmfExternalFunction::getClassTypeID())
-    return new FmfExternalFunction();
-  else if (type == FmfMathExpr::getClassTypeID())
-    return new FmfMathExpr();
-  else if (type == FmfWaveSinus::getClassTypeID())
-    return new FmfWaveSinus();
-  else if (type == FmfWaveSpectrum::getClassTypeID())
-    return new FmfWaveSpectrum();
-  else if (type == FmfUserDefined::getClassTypeID())
-    return new FmfUserDefined();
+#define CREATE_FUNC(T) if (type == T::getClassTypeID()) return new T()
+
+  CREATE_FUNC(FmfLinVar);
+  CREATE_FUNC(FmfConstant);
+  CREATE_FUNC(FmfSinusoidal);
+  CREATE_FUNC(FmfComplSinus);
+  CREATE_FUNC(FmfDelayedComplSinus);
+  CREATE_FUNC(FmfStep);
+  CREATE_FUNC(FmfScale);
+  CREATE_FUNC(FmfSpline);
+  CREATE_FUNC(FmfRamp);
+  CREATE_FUNC(FmfSquarePuls);
+  CREATE_FUNC(FmfDiracPuls);
+  CREATE_FUNC(FmfLimRamp);
+  CREATE_FUNC(FmfSmoothTraj);
+  CREATE_FUNC(FmfLinVelVar);
+  CREATE_FUNC(FmfDeviceFunction);
+  CREATE_FUNC(FmfExternalFunction);
+  CREATE_FUNC(FmfMathExpr);
+  CREATE_FUNC(FmfWaveSinus);
+  CREATE_FUNC(FmfWaveSpectrum);
+  CREATE_FUNC(FmfUserDefined);
 
   return NULL;
 }

--- a/vpmDB/FmFuncAdmin.H
+++ b/vpmDB/FmFuncAdmin.H
@@ -11,16 +11,13 @@
 #include "FFaLib/FFaTypeCheck/FFaTypeCheck.H"
 #include <string>
 #include <vector>
-#include <map>
 
 class FmMathFuncBase;
 
 
 struct FmFuncTypeInfo
 {
-  FmFuncTypeInfo() { funcType = FFaTypeCheck::NO_TYPE_ID; funcMenuEnum = -1; }
-  FmFuncTypeInfo(const std::string& name, int ft = FFaTypeCheck::NO_TYPE_ID)
-  { listName = name; funcType = ft; funcMenuEnum = -1; }
+  FmFuncTypeInfo(const char* fn = NULL, int ft = FFaTypeCheck::NO_TYPE_ID);
   int getFuncType() const;
 
   std::string listName;
@@ -28,33 +25,21 @@ struct FmFuncTypeInfo
   int funcMenuEnum;
 };
 
-typedef std::map<int,FmFuncTypeInfo> FuncInfoMap;
 
-
-class FmFuncAdmin
+namespace FmFuncAdmin
 {
-  static void init();
+  const std::vector<int>& getAllowableSprDmpFuncTypes();
 
-public:
-  static const std::vector<int>& getAllowableSprDmpFuncTypes();
+  bool hasSmartPoints(int type);
 
-  static bool hasSmartPoints(int type);
+  void getCompatibleFunctionTypes(std::vector<FmFuncTypeInfo>& toFill,
+                                  FmMathFuncBase* compatibleFunc);
 
-  static void getCompatibleFunctionTypes(std::vector<FmFuncTypeInfo>& toFill,
-					 FmMathFuncBase* compatibleFunc);
+  FmMathFuncBase* createFunction(int type);
 
-  static FmMathFuncBase* createFunction(int type);
+  void clearInfoTable();
 
-  static void clearInfoTable() { itsFuncInfoTable.clear(); }
-
-private:
-  static FuncInfoMap itsFuncInfoTable;
-  static std::vector<int> allowableSprDmpFuncs;
-
-  static bool isAllowableSprDmpFuncType(int type);
-
-public:
-  enum
+  enum FuncType
   {
     INTERNAL = -2,
     UNDEFINED = -1,
@@ -96,6 +81,6 @@ public:
 
     USER_HEADING
   };
-};
+}
 
 #endif

--- a/vpmDB/FmJacket.C
+++ b/vpmDB/FmJacket.C
@@ -38,7 +38,7 @@ std::ostream& FmJacket::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 

--- a/vpmDB/FmRiser.C
+++ b/vpmDB/FmRiser.C
@@ -47,7 +47,7 @@ std::ostream& FmRiser::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 

--- a/vpmDB/FmSoilPile.C
+++ b/vpmDB/FmSoilPile.C
@@ -40,7 +40,7 @@ std::ostream& FmSoilPile::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 

--- a/vpmDB/FmStructAssembly.C
+++ b/vpmDB/FmStructAssembly.C
@@ -21,7 +21,7 @@ std::ostream& FmStructAssembly::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 

--- a/vpmDB/FmSubAssembly.C
+++ b/vpmDB/FmSubAssembly.C
@@ -224,7 +224,7 @@ std::ostream& FmSubAssembly::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,myHeadMap);
+    FmDB::reportMembers(os,&myHeadMap);
   else
     this->writeFMF(myModelFile.getValue());
 
@@ -244,7 +244,7 @@ bool FmSubAssembly::writeFMF(const std::string& fileName) const
 
   std::string metaData = "!Submodel: " + this->getIdString();
   std::ofstream fs(fullName.c_str(),std::ios::out);
-  if (FmDB::reportAll(fs,false,myHeadMap,metaData.c_str()))
+  if (FmDB::reportAll(fs,false,&myHeadMap,metaData.c_str()))
     return true;
 
   ListUI <<" ==> Failure writing Subassembly file: "<< fullName <<"\n";

--- a/vpmDB/FmTurbine.C
+++ b/vpmDB/FmTurbine.C
@@ -229,7 +229,7 @@ double FmTurbine::getRotorSize() const
 
 void FmTurbine::draw() const
 {
-  FmDB::displayAll(*this->getHeadMap());
+  FmDB::displayAll(this->getHeadMap());
 }
 
 
@@ -246,7 +246,7 @@ std::ostream& FmTurbine::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -710,7 +710,7 @@ std::ostream& FmTower::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -772,7 +772,7 @@ std::ostream& FmNacelle::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -829,7 +829,7 @@ std::ostream& FmGenerator::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -889,7 +889,7 @@ std::ostream& FmGearBox::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -953,7 +953,7 @@ std::ostream& FmShaft::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -1012,7 +1012,7 @@ std::ostream& FmRotor::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 
@@ -1070,7 +1070,7 @@ std::ostream& FmBlade::writeFMF(std::ostream& os)
   os <<"}\n\n";
 
   if (myModelFile.getValue().empty())
-    FmDB::reportMembers(os,*this->getHeadMap());
+    FmDB::reportMembers(os,this->getHeadMap());
   else
     this->FmSubAssembly::writeFMF(myModelFile.getValue());
 


### PR DESCRIPTION
The classes with static methods only are now replaced by equivalent namespaces for the convenience.
The static methods that used to be declared as private (or protected) are now defined in anonymous namespaces in the implementation file instead and therefore do not need be be declared in header files (same with the private attributes), making the header files shorter.