### PR TITLE
Prismatic/cylindric joint modelling issues

### DIFF
--- a/vpmDB/FmIsPositionedBase.H
+++ b/vpmDB/FmIsPositionedBase.H
@@ -59,7 +59,7 @@ public:
   virtual std::string getLinkIDString(bool = false) const { return ""; }
 
   virtual bool isTranslatable() const { return false; }
-  virtual bool isRotatable() const { return false; }
+  virtual char isRotatable() const { return false; }
 
   FmAssemblyBase* getPositionedAssembly() const;
 

--- a/vpmDB/FmPart.H
+++ b/vpmDB/FmPart.H
@@ -130,7 +130,7 @@ public:
 
   virtual void setLocalCS(const FaMat34& localCS);
 
-  virtual bool isRotatable() const { return this->isTranslatable(); }
+  virtual char isRotatable() const { return this->isTranslatable(); }
   virtual bool isTranslatable() const;
 
   // FE mesh generation

--- a/vpmDB/FmRefPlane.H
+++ b/vpmDB/FmRefPlane.H
@@ -26,7 +26,7 @@ public:
   virtual bool clone(FmBase* obj, int depth);
 
   virtual bool isTranslatable() const { return true; }
-  virtual bool isRotatable() const    { return true; }
+  virtual char isRotatable() const    { return true; }
 
   const FmColor& getRGBColor() const { return myRGBColor.getValue(); }
   bool setRGBColor(const FmColor& col);

--- a/vpmDB/FmSMJointBase.H
+++ b/vpmDB/FmSMJointBase.H
@@ -28,7 +28,7 @@ public:
 
   FmTriad* getItsMasterTriad() const { return itsMasterTriad.getPointer(); }
   void setAsMasterTriad(FmTriad* triad) { itsMasterTriad.setRef(triad); }
-  void removeItsMasterTriad() { itsMasterTriad.setRef(0); }
+  void removeItsMasterTriad() { itsMasterTriad.setRef(NULL); }
   bool swapMasterAndSlave();
 
   virtual void getMasterTriads(std::vector<FmTriad*>& triadsToFill) const;
@@ -37,8 +37,8 @@ public:
   virtual FaMat34 getGlobalCS() const;
   virtual void    setGlobalCS(const FaMat34& globalMat, bool moveAlong = false);
 
-  virtual bool isTranslatable() const ;
-  virtual bool isRotatable() const ;
+  virtual bool isTranslatable() const;
+  virtual char isRotatable() const;
 
   bool isMasterMovedAlong() const { return IAmMovingMasterTriadAlong.getValue(); }
   bool isSlaveMovedAlong()  const { return IAmMovingSlaveTriadAlong.getValue(); }

--- a/vpmDB/FmTriad.H
+++ b/vpmDB/FmTriad.H
@@ -86,7 +86,7 @@ public:
 
   bool isSlaveTriad(bool realSlavesOnly = false) const;
   bool isMasterTriad(bool realMastersOnly = false) const;
-  bool isMultiMaster() const;
+  bool isMultiMaster(bool includingCam = true) const;
   bool isInLinJoint() const;
 
   virtual std::string getLinkIDString(bool objPrefix) const;
@@ -111,9 +111,9 @@ public:
   FaMat34 getRelativeCS(const FmLink* link) const;
 
   virtual bool isTranslatable() const { return this->isTranslatable(NULL); }
-  virtual bool isRotatable() const { return this->isRotatable(NULL); }
+  virtual char isRotatable() const { return this->isRotatable(NULL); }
   bool isTranslatable(const FmJointBase* jointToIgnore) const;
-  bool isRotatable(const FmJointBase* jointToIgnore) const;
+  char isRotatable(const FmJointBase* jointToIgnore) const;
 
   bool hasReferences() const;
   bool showSymbol() const;


### PR DESCRIPTION
When creating a line joint (prismatic or cylindric) between existing triads, one of the end triads can not already be member of an existing line object of another joint. Neither can both end triads be member of two different line objects. Only if the two end triads matches the end triads of the same existing line it is allowed, and that line is then reused without the option to decline it.
This is to ensure that the multi-master triads will not have conflicting orientations if used by several multi-master joints.

Also extending the `FmTriad::isRotatable()` method, to detect whether a multi-master triad can rotate about the local Z-axis of the joint in the modelling stage.