### PR TITLE
Silence messages on obsolete hash-commands

### DIFF
--- a/vpmDB/FmEngine.C
+++ b/vpmDB/FmEngine.C
@@ -125,8 +125,10 @@ std::string FmEngine::getInfoString() const
   if (this->isDriveFile())
     return myFunction->getInfoString();
 
-  if (this->isControlOutEngine())
-    return this->getSensor()->getMeasured()->getInfoString();
+  if (FmSensorBase* sensor = mySensor.getFirstPtr(); sensor)
+    if (mySensor.size() == 1 && sensor->isControlOutput())
+      if (FmIsMeasuredBase* measured = sensor->getMeasured(); measured)
+        return measured->getInfoString();
 
   return this->FmBase::getInfoString();
 }
@@ -158,9 +160,9 @@ bool FmEngine::isActive() const
 
 bool FmEngine::isControlOutEngine() const
 {
-  FmSensorBase* sensor = mySensor.getFirstPtr();
-  if (sensor && mySensor.size() == 1)
-    return sensor->isControlOutput();
+  if (FmSensorBase* sensor = mySensor.getFirstPtr(); sensor)
+    if (mySensor.size() == 1)
+      return sensor->isControlOutput();
 
   return false;
 }
@@ -219,8 +221,7 @@ void FmEngine::setEngineToLinkFunctionFrom(FmEngine* engine)
 
 FmBase* FmEngine::duplicate() const
 {
-  FmVesselMotion* vm = NULL;
-  if (this->hasReferringObjs(vm,"motionEngine"))
+  if (FmVesselMotion* vm; this->hasReferringObjs(vm,"motionEngine"))
     return NULL; // Not allowed to duplicate RAO motion engines directly
 
   FmEngine* newEng = static_cast<FmEngine*>(this->copy(FmBase::SHALLOW));
@@ -286,16 +287,14 @@ bool FmEngine::getUsers(std::vector<FmModelMemberBase*>& toFill,
 
   if (!recursive)
     toFill.insert(toFill.end(),engines.begin(),engines.end());
-  else for (FmModelMemberBase* engine : engines)
-  {
-    FmEngine* e = static_cast<FmEngine*>(engine);
-    if (!e->getUsers(toFill,true))
-      // This engine has no direct users, but add the engine itself instead if
-      // it is an output sensor or specified through a beta feature command
-      if (e->myOutput.getValue() ||
-          betaFeatureEngines.find(e->getBaseID()) != betaFeatureEngines.end())
-        toFill.push_back(engine);
-  }
+  else
+    for (FmModelMemberBase* obj : engines)
+      if (FmEngine* e = static_cast<FmEngine*>(obj); !e->getUsers(toFill,true))
+        // This engine has no direct users, but add the engine itself instead if
+        // it is an output sensor or specified through a beta feature command
+        if (e->myOutput.getValue() ||
+            betaFeatureEngines.find(e->getBaseID()) != betaFeatureEngines.end())
+          toFill.push_back(obj);
 
   return toFill.size() > n;
 }
@@ -312,25 +311,21 @@ FmSensorBase* FmEngine::getUniqueSensor() const
       ++first;
 
   for (size_t i = first; i < nArg; i++)
-  {
-    FmSensorBase* s = this->getSensor(i);
-    if (!s) continue;
-
-    FmEngine* e = dynamic_cast<FmEngine*>(s->getMeasured());
-    if (e)
+    if (FmSensorBase* s = this->getSensor(i); s)
     {
-      FmSensorBase* us = e->getUniqueSensor();
-      if (us != sensor)
+      if (FmEngine* e = dynamic_cast<FmEngine*>(s->getMeasured()); e)
       {
-	if (i == first && us)
-	  sensor = us;
-	else
-	  return NULL;
+        if (FmSensorBase* us = e->getUniqueSensor(); us != sensor)
+        {
+          if (i == first && us)
+            sensor = us;
+          else
+            return NULL;
+        }
       }
+      else if (s != sensor)
+        return NULL;
     }
-    else if (s != sensor)
-      return NULL;
-  }
 
   return sensor;
 }
@@ -346,17 +341,14 @@ bool FmEngine::initGetValue() const
     retVal = myFunction->initGetValue();
 
   size_t nArg = this->getNoArgs();
-  if (nArg == 1 || !retVal) return retVal;
+  if (nArg == 1 || !retVal)
+    return retVal;
 
   for (size_t i = 0; i < nArg; i++)
-  {
-    FmSensorBase* s = this->getSensor(i);
-    if (!s) continue;
-
-    FmEngine* e = dynamic_cast<FmEngine*>(s->getMeasured());
-    if (e && !e->initGetValue())
-      return false;
-  }
+    if (FmSensorBase* s = this->getSensor(i); s)
+      if (FmEngine* eng = dynamic_cast<FmEngine*>(s->getMeasured()); eng)
+        if (!eng->initGetValue())
+          return false;
 
   return true;
 }
@@ -375,12 +367,10 @@ bool FmEngine::getValue(double x, double& y) const
   DoubleVec args(nArg,0.0);
   args.front() = x;
   for (size_t i = 0; i < nArg; i++)
-  {
-    FmSensorBase* s = this->getSensor(i);
-    FmEngine* e = s ? dynamic_cast<FmEngine*>(s->getMeasured()) : NULL;
-    if (e && !e->getValue(x,args[i]))
-      return false;
-  }
+    if (FmSensorBase* s = this->getSensor(i); s)
+      if (FmEngine* eng = dynamic_cast<FmEngine*>(s->getMeasured()); eng)
+        if (!eng->getValue(x,args[i]))
+          return false;
 
   y = myFunction->getValue(args,ierr);
   return ierr == 0;
@@ -464,9 +454,9 @@ void FmEngine::setFunction(FmMathFuncBase* func)
 const std::string& FmEngine::getEntityName(size_t i) const
 {
   if (i < myEntityNames.getValue().size())
-    if (this->getSensor(i))
-      if (this->getSensor(i)->hasEntityChoice())
-	return myEntityNames.getValue()[i];
+    if (FmSensorBase* sensor = this->getSensor(i); sensor)
+      if (sensor->hasEntityChoice())
+        return myEntityNames.getValue()[i];
 
   static const std::string empty;
   return empty;
@@ -476,9 +466,9 @@ const std::string& FmEngine::getEntityName(size_t i) const
 int FmEngine::getEntity(size_t i) const
 {
   if (i < myEntities.getValue().size())
-    if (this->getSensor(i))
-      if (this->getSensor(i)->hasEntityChoice())
-	return myEntities.getValue()[i];
+    if (FmSensorBase* sensor = this->getSensor(i); sensor)
+      if (sensor->hasEntityChoice())
+        return myEntities.getValue()[i];
 
   return -1;
 }
@@ -487,9 +477,9 @@ int FmEngine::getEntity(size_t i) const
 int FmEngine::getDof(size_t i) const
 {
   if (i < myDofs.getValue().size())
-    if (this->getSensor(i))
-      if (this->getSensor(i)->hasDofChoice())
-	return myDofs.getValue()[i];
+    if (FmSensorBase* sensor = this->getSensor(i); sensor)
+      if (sensor->hasEntityChoice())
+        return myDofs.getValue()[i];
 
   return -1;
 }
@@ -583,11 +573,8 @@ bool FmEngine::cloneLocal(FmBase* obj, int depth)
   FmEngine* copyObj = static_cast<FmEngine*>(obj);
 
   if (depth == FmBase::SHALLOW || depth >= FmBase::DEEP_APPEND)
-  {
-    size_t nArg = copyObj->mySensor.size();
-    for (size_t i = 0; i < nArg; i++)
+    for (size_t i = 0; i < copyObj->mySensor.size(); i++)
       this->setSensor(copyObj->getSensor(i),-i);
-  }
 
   if (depth >= FmBase::DEEP_APPEND)
   {
@@ -613,24 +600,15 @@ void FmEngine::initAfterResolve()
     this->setSensor(mySensor[i],i);
     if (dynamic_cast<FmStrainRosette*>(mySensor[i]->getMeasured()))
       if (FmDB::getModelFileVer() < FFaVersionNumber(7,3,2,10) && i < myDofs.getValue().size())
-      {
         // Increment the strain rosette sensor DOF for older model files
         // which only had the GAGE_[123] choices available
-        int iDof = myDofs.getValue()[i];
-        if (iDof < FmIsMeasuredBase::NUM_DOF-4)
+        if (int iDof = myDofs.getValue()[i]; iDof < FmIsMeasuredBase::NUM_DOF-4)
           this->setDof(iDof+4,i);
-      }
   }
-
-  FFaString eDesc(this->getUserDescription());
-  if (eDesc.hasSubString("#TimeStepEngine") && FmDB::getActiveAnalysis()->myTimeIncEngine.isNull())
-    ListUI <<"\n---> WARNING: Ignoring #TimeStepEngine"
-           <<" in the description field for "<< this->getIdString()
-           <<".\n     Select a General Function in the \"Time increment\" field"
-           <<" in the Solver Setup dialog box instead.\n";
 
   // Conversion from older model files: Wave spectrum beta feature
   int nWave, spectrum;
+  const FFaString eDesc = this->getUserDescription();
   if ((nWave = eDesc.getIntAfter("#PiersonMoskowitz")))
     spectrum = FmfWaveSpectrum::PiersonMoskowitz;
   else if ((nWave = eDesc.getIntAfter("#JONSWAP")))
@@ -651,8 +629,8 @@ void FmEngine::initAfterResolve()
   newFunc->nComp.setValue(nWave < 0 ? -nWave : nWave);
 
   // Move preview curve if old function has one
-  FmCurveSet* curve = oldFunc->getPreviewCurve();
-  if (curve) curve->setFunctionRef(newFunc);
+  if (FmCurveSet* curve = oldFunc->getPreviewCurve(); curve)
+    curve->setFunctionRef(newFunc);
 
   // Transfer the function parameters
   newFunc->myHs.setValue(oldFunc->getAmplitude());
@@ -755,8 +733,7 @@ int FmEngine::printSolverEntry(FILE* fp)
   if (!myFunction.isNull()) // A function is optional
     fprintf(fp,"  functionId = %d\n", myFunction->getBaseID());
 
-  size_t nArg = this->getNoArgs();
-  if (nArg > 0)
+  if (size_t nArg = this->getNoArgs(); nArg > 0)
   {
     fprintf(fp,"  nArg = %u, argSensorId =", (unsigned int)nArg);
     for (size_t i = 0; i < nArg; i++)

--- a/vpmDB/FmFppOptions.C
+++ b/vpmDB/FmFppOptions.C
@@ -8,7 +8,6 @@
 #include "FFaLib/FFaString/FFaParse.H"
 #include "FFaLib/FFaDefinitions/FFaMsg.H"
 
-#include "vpmDB/FmDB.H"
 #include "vpmDB/FmFppOptions.H"
 
 
@@ -37,12 +36,6 @@ FmFppOptions::FmFppOptions()
 FmFppOptions::~FmFppOptions()
 {
   this->disconnect();
-}
-
-
-bool FmFppOptions::useNCode() const
-{
-  return addOptions.getValue().find("#useNCode") < std::string::npos;
 }
 
 
@@ -108,7 +101,7 @@ bool FmFppOptions::readAndConnect(std::istream& is, std::ostream&)
 	 <<"\n     in the \"Model Preferences\" dialog.\n";
 
   if (histMaxX.wasOnFile() && histMinX.wasOnFile())
-    obj->histRange.setValue(std::make_pair(histMinX.getValue(),histMaxX.getValue()));
+    obj->histRange.setValue({histMinX.getValue(),histMaxX.getValue()});
 
   if (histStressType.wasOnFile() && histStrainType.wasOnFile())
   {

--- a/vpmDB/FmFppOptions.H
+++ b/vpmDB/FmFppOptions.H
@@ -11,8 +11,6 @@
 #include "vpmDB/FmSimulationModelBase.H"
 #include "FFaLib/FFaString/FFaEnum.H"
 
-typedef std::pair<double,double> FmRange;
-
 
 class FmFppOptions : public FmSimulationModelBase
 {
@@ -22,8 +20,6 @@ public:
   FmFppOptions();
 
   virtual const char* getUITypeName() const { return "FppOptions"; }
-
-  bool useNCode() const;
 
   virtual bool clone(FmBase* obj, int depth);
   virtual std::ostream& writeFMF(std::ostream& os = std::cout);
@@ -61,8 +57,10 @@ public:
   FFaField<double> pvxGate;
   FFaField<double> biaxGate;
 
-  FFaField<int>     histNBins;
+  using FmRange = std::pair<double,double>;
+
   FFaField<FmRange> histRange;
+  FFaField<int>     histNBins;
 
   FFaField<std::string> addOptions;
 };

--- a/vpmDB/FmGenericDBObject.C
+++ b/vpmDB/FmGenericDBObject.C
@@ -19,6 +19,11 @@ FmGenericDBObject::FmGenericDBObject()
 {
   Fmd_CONSTRUCTOR_INIT(FmGenericDBObject);
 
+  // Add the base ID to the list of fields to be saved in the model file,
+  // as this object may be referred by other Generic DB objects in the model.
+  // It should therefore preserve the same base ID from session to session.
+  FFA_FIELD_INIT(myBaseID, -1, "BASE_ID");
+
   FFA_FIELD_DEFAULT_INIT(objectType,"OBJECT_TYPE");
   FFA_FIELD_DEFAULT_INIT(objectDefinition,"OBJECT_DEFINITION");
 }
@@ -70,10 +75,18 @@ bool FmGenericDBObject::readAndConnect(std::istream& is, std::ostream&)
 
 int FmGenericDBObject::printSolverEntry(FILE* fp)
 {
+  std::string definition = objectDefinition.getValue();
+  // Remove trailing newlines, if any
+  while (definition.back() == '\n')
+    definition.pop_back();
+  // Insert two spaces in front of each line
+  for (size_t i = definition.size(); i > 0; i--)
+    if (definition[i] == '\n')
+      definition.insert(i+1,2,' ');
+
   fprintf(fp, "'Generic DB-object\n");
   fprintf(fp, "&%s\n", objectType.getValue().c_str());
   this->printID(fp);
-  fprintf(fp, "%s\n", objectDefinition.getValue().c_str());
-  fprintf(fp, "/\n\n");
+  fprintf(fp, "  %s\n/\n\n", definition.c_str());
   return 0;
 }

--- a/vpmDB/FmSolverParser.C
+++ b/vpmDB/FmSolverParser.C
@@ -95,21 +95,17 @@ bool FmSolverParser::preSimuleCheck()
   std::vector<FmSensorBase*> allSensors;
   FmDB::getAllSensors(allSensors);
   for (FmSensorBase* sens : allSensors)
-  {
-    FmStrainRosette* ros = dynamic_cast<FmStrainRosette*>(sens->getMeasured());
-    if (ros)
+    if (FmStrainRosette* ros = dynamic_cast<FmStrainRosette*>(sens->getMeasured()); ros)
     {
       std::vector<FmEngine*> engines;
       sens->getEngines(engines);
       for (FmEngine* eng : engines)
-        if (eng->isActive())
-          if (ros->rosetteLink->enforceStrainRosetteRecovery())
-            ListUI <<"  -> Activating strain rosette recovery during dynamics"
-                   <<" simulation\n     for "<< ros->rosetteLink->getIdString()
-                   <<" since it is used as argument in "<< eng->getIdString()
-                   <<"\n";
+        if (eng->isActive() && ros->rosetteLink->enforceStrainRosetteRecovery())
+          ListUI <<"  -> Activating strain rosette recovery during dynamics"
+                 <<" simulation\n     for "<< ros->rosetteLink->getIdString()
+                 <<", since it is used as argument in "<< eng->getIdString()
+                 <<".\n";
     }
-  }
 
   FmfSpline::setAllSplineICODE();
   return true;
@@ -172,9 +168,21 @@ int FmSolverParser::writeFullFile()
 
 int FmSolverParser::writeHeading()
 {
+  FmMechanism* mech = FmDB::getMechanismObject();
+  FFaString mDesc = mech->getUserDescription();
+  if (mDesc.hasSubString("#UseEngines"))
+  {
+    // Beta feature: Flag usage of engines not referred by other objects.
+    // For instance, if a Generic DB object is defined referring to an engine
+    // object otherwise not used, it needs to be listed by #UseEngines
+    // to ensure that it is written to the solver input file.
+    int engineIds[100];
+    if (int nEng = mDesc.getIntsAfter("#UseEngines",100,engineIds); nEng > 0)
+      FmEngine::betaFeatureEngines.insert(engineIds,engineIds+nEng);
+  }
+
   fprintf(myFile,"&HEADING\n");
-  fprintf(myFile,"  modelFile = '%s'\n",
-	  FmDB::getMechanismObject()->getModelFileName().c_str());
+  fprintf(myFile,"  modelFile = '%s'\n",mech->getModelFileName().c_str());
   fprintf(myFile,"  version = 3.0\n");
   fprintf(myFile,"/\n\n");
   return 0;
@@ -191,16 +199,7 @@ int FmSolverParser::writeEnvironment()
   fprintf(myFile,"  gravity  =%17.9e %17.9e %17.9e\n",grav[0],grav[1],grav[2]);
   if (seastate)
   {
-    FFaString mDesc = FmDB::getMechanismObject()->getUserDescription();
     fprintf(myFile,"  rhoWater =%17.9e\n",seastate->waterDensity.getValue());
-    if (mDesc.hasSubString("#MudDensity"))
-      ListUI <<"\n---> WARNING: Ignoring #MudDensity in the"
-	     <<" Model description field of the Model Preferences dialog box."
-	     <<"\n     Set this in the Riser property view instead.\n";
-    if (mDesc.hasSubString("#MarineGrowth"))
-      ListUI <<"\n---> WARNING: Ignoring #MarineGrowth in the"
-	     <<" Model description field of the Model Preferences dialog box."
-	     <<"\n     Set this in the Sea Environment dialog box instead.\n";
     double rhoMG = seastate->growthDensity.getValue();
     double thickMG = seastate->growthThickness.getValue();
     const std::pair<double,double>& limMG = seastate->growthLimit.getValue();
@@ -225,8 +224,10 @@ int FmSolverParser::writeEnvironment()
     }
 
     // Beta feature: Wave theory option
-    if (mDesc.hasSubString("#waveTheory"))
-      fprintf(myFile,"  waveTheory = %d\n",mDesc.getIntAfter("waveTheory"));
+    FFaString mDesc = FmDB::getMechanismObject()->getUserDescription();
+    if (int waveTheory = mDesc.getIntAfter("#waveTheory"); waveTheory > 0)
+      fprintf(myFile,"  waveTheory = %d\n",waveTheory);
+
     FmMathFuncBase* wFunc = seastate->waveFunction.getPointer();
     if (wFunc) fprintf(myFile,"  waveFunction = %d\n",wFunc->getBaseID());
     FmMathFuncBase* cFunc = seastate->currFunction.getPointer();
@@ -304,17 +305,6 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
       // Beta feature: Specify element groups for stress recovery
       std::string elmGroups = lDesc.getTextAfter("#recover-stress","#");
 
-      if (recover%2 < 1 && lDesc.hasSubString("#recover-stress"))
-        ListUI <<"\n---> WARNING: Ignoring #recover-stress"
-               <<" in the description field for "<< activePart->getIdString()
-               <<".\n     Set this in the \"Advanced\" tab"
-               <<" of the part property panel instead.\n";
-      if (recover < 2 && lDesc.hasSubString("#recover-gage"))
-        ListUI <<"\n---> WARNING: Ignoring #recover-gage"
-               <<" in the description field for "<< activePart->getIdString()
-               <<".\n     Set this in the \"Advanced\" tab"
-               <<" of the part property panel instead.\n";
-
       std::vector<std::string> fmxFiles;
       fmxFiles.reserve(7);
 
@@ -369,8 +359,7 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
         fprintf(myFile,"\n");
       }
 
-      int ngen = activePart->nGenModes.getValue();
-      if (ngen > 0)
+      if (int ngen = activePart->nGenModes.getValue(); ngen > 0)
         fprintf(myFile,"  numGenDOFs = %d\n",ngen);
 
       if (activePart->hasLoads())
@@ -528,12 +517,6 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
       }
     fprintf(myFile,"  shadowPosAlg = %d\n", shadowPosAlg);
 
-    if (lDesc.hasSubString("#ShadowPosAlg"))
-      ListUI <<"\n---> WARNING: Ignoring #ShadowPosAlg <num>"
-	     <<" in the description field for "<< activePart->getIdString()
-	     <<".\n     Set this in the \"Advanced\" tab"
-	     <<" of the part property window instead.\n";
-
     if (shadowPosAlg == 1)
     {
       // Corotated coordinate system reference triads
@@ -558,8 +541,7 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
       fprintf(myFile,"  stressStiffFlag = 0\n");
 
     // Beta feature: Projection of internal forces
-    int projFlag = lDesc.getIntAfter("#Projection");
-    if (projFlag > 0)
+    if (int projFlag = lDesc.getIntAfter("#Projection"); projFlag > 0)
       fprintf(myFile,"  projDefFlag = %d\n",projFlag);
 
     // Centripetal force correction
@@ -575,22 +557,6 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
 	break;
       }
 
-    if (lDesc.hasSubString("#MassCorrection"))
-      ListUI <<"\n---> WARNING: Ignoring #MassCorrection"
-	     <<" in the description field for "<< activePart->getIdString()
-	     <<".\n     Set this in the \"Advanced\" tab"
-	     <<" of the part property window instead.\n";
-    if (lDesc.hasSubString("#NoMassCorrection"))
-      ListUI <<"\n---> WARNING: Ignoring #NoMassCorrection"
-	     <<" in the description field for "<< activePart->getIdString()
-	     <<".\n     Set this in the \"Advanced\" tab"
-	     <<" of the part property window instead.\n";
-    if (lDesc.hasSubString("#MassCorrFlag"))
-      ListUI <<"\n---> WARNING: Ignoring #MassCorrFlag <num>"
-	     <<" in the description field for "<< activePart->getIdString()
-	     <<".\n     Set this in the \"Advanced\" tab"
-	     <<" of the part property window instead.\n";
-
     // Scaling of dynamic properties
     double stiffScale = activePart->stiffnessScale.getValue();
     fprintf(myFile,"  stiffScale =%17.9e\n",stiffScale);
@@ -598,25 +564,22 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
     fprintf(myFile,"  massScale  =%17.9e\n",massScale);
 
     // Beta feature: Time-dependent stiffness scaling
-    int stifSclEngine = lDesc.getIntAfter("#StiffScaleEngine");
-    if (stifSclEngine > 0) {
-      fprintf(myFile,"  stiffEngineId = %d\n", stifSclEngine);
-      FmEngine::betaFeatureEngines.insert(stifSclEngine);
+    if (int engineId = lDesc.getIntAfter("#StiffScaleEngine"); engineId > 0) {
+      fprintf(myFile,"  stiffEngineId = %d\n", engineId);
+      FmEngine::betaFeatureEngines.insert(engineId);
     }
 
     // Beta feature: Time-dependent mass scaling
-    int massSclEngine = lDesc.getIntAfter("#MassScaleEngine");
-    if (massSclEngine > 0) {
-      fprintf(myFile,"  massEngineId = %d\n", massSclEngine);
-      FmEngine::betaFeatureEngines.insert(massSclEngine);
+    if (int engineId = lDesc.getIntAfter("#MassScaleEngine"); engineId > 0) {
+      fprintf(myFile,"  massEngineId = %d\n", engineId);
+      FmEngine::betaFeatureEngines.insert(engineId);
     }
 
     // Structural damping coefficients
     fprintf(myFile,"  alpha1 =%17.9e," ,activePart->alpha1.getValue());
     fprintf(myFile,"  alpha2 =%17.9e\n",activePart->alpha2.getValue());
 
-    DoubleVec alpha3, alpha4;
-    if (activePart->getCompModesAlpha(alpha3,1))
+    if (DoubleVec alpha3; activePart->getCompModesAlpha(alpha3,1))
     {
       fprintf(myFile,"  alpha3 =%17.9e",alpha3.front());
       for (j = 1; j < alpha3.size(); j++) {
@@ -625,7 +588,7 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
       }
       fprintf(myFile,"\n");
     }
-    if (activePart->getCompModesAlpha(alpha4,2))
+    if (DoubleVec alpha4; activePart->getCompModesAlpha(alpha4,2))
     {
       fprintf(myFile,"  alpha4 =%17.9e",alpha4.front());
       for (j = 1; j < alpha4.size(); j++) {
@@ -636,9 +599,8 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
     }
 
     // Possibly time-dependent structural damping
-    int structDmpEngine = activePart->getStructDmpEngineId();
-    if (structDmpEngine > 0)
-      fprintf(myFile,"  strDmpEngineId = %d\n", structDmpEngine);
+    if (int engineId = activePart->getStructDmpEngineId(); engineId > 0)
+      fprintf(myFile,"  strDmpEngineId = %d\n", engineId);
 
     // Part position
     FaMat34 lCS = activePart->getGlobalCS();
@@ -663,8 +625,7 @@ int FmSolverParser::writeParts(std::vector<FmPart*>& gageParts)
 
     if (cgTriadId > 0)
     {
-      FmModelMemberBase* cgTriad = FmDB::findObject(cgTriadId);
-      if (cgTriad)
+      if (FmModelMemberBase* cgTriad = FmDB::findObject(cgTriadId); cgTriad)
         ListUI <<"  -> Detected center of gravity at "<< cgTriad->getIdString()
 	       <<" for "<< activePart->getIdString() <<"\n";
     }
@@ -860,8 +821,7 @@ int FmSolverParser::writeJoints()
       if (activeJoint->isOfType(FmCamJoint::getClassTypeID()))
       {
 	urSlave = activeJoint->getSlaveTriad()->getGlobalCS();
-	Fm1DMaster* master = ((FmMMJointBase*)activeJoint)->getMaster();
-	if (master)
+	if (Fm1DMaster* master = ((FmMMJointBase*)activeJoint)->getMaster(); master)
 	{
 	  slideValue = master->getSliderPosition(urSlider,urSlave.translation());
 	  ur = urSlider;
@@ -887,19 +847,6 @@ int FmSolverParser::writeJoints()
       fprintf(myFile,"                   %17.9e %17.9e %17.9e %17.9e\n",
 	      ur[0][2],ur[1][2],ur[2][2],ur[3][2]);
 
-      std::string ignored;
-      if (jDesc.hasSubString("#InitTXvel")) ignored.append(" #InitTXvel");
-      if (jDesc.hasSubString("#InitTYvel")) ignored.append(" #InitTYvel");
-      if (jDesc.hasSubString("#InitTZvel")) ignored.append(" #InitTZvel");
-      if (jDesc.hasSubString("#InitRXvel")) ignored.append(" #InitRXvel");
-      if (jDesc.hasSubString("#InitRYvel")) ignored.append(" #InitRYvel");
-      if (jDesc.hasSubString("#InitRZvel")) ignored.append(" #InitRZvel");
-      if (!ignored.empty())
-	ListUI <<"\n---> WARNING: Ignoring"<< ignored
-	       <<" in the description field for "<< activeJoint->getIdString()
-	       <<".\n     Use the \"Initial velocity\" field in the"
-	       <<" joint property window instead.\n";
-
       FmCylJoint* screwJoint = NULL;
       int CVJointID = 0;
       int nJVar = 0;
@@ -916,11 +863,6 @@ int FmSolverParser::writeJoints()
 	// *** REVOLUTE JOINT ***
 
 	fprintf(myFile,"  type         = 1\n");
-	if (jDesc.hasSubString("#FreeZ"))
-	  ListUI <<"\n---> WARNING: Ignoring #FreeZ"
-		 <<" in the description field for "<< activeJoint->getIdString()
-		 <<".\n     Use the \"Z translation DOF\" toggle"
-		 <<" in the joint property window instead.\n";
 
 	iDof.push_back(5);
 	if (activeJoint->isLegalDOF(2))
@@ -1287,11 +1229,6 @@ int FmSolverParser::writeJoints()
 	// *** CAM JOINT ***
 
 	fprintf(myFile,"  type         = 7\n");
-	if (jDesc.hasSubString("#SpringActiveRadius"))
-	  ListUI <<"\n---> WARNING: Ignoring #SpringActiveRadius"
-		 <<" in the description field for "<< activeJoint->getIdString()
-		 <<".\n     Use the \"Thickness\" field"
-		 <<" in the joint property window instead.\n";
 	fprintf(myFile,"  camThickness = %17.9e\n",
 		((FmCamJoint*)activeJoint)->getThickness());
 
@@ -1425,18 +1362,11 @@ int FmSolverParser::writeJoints()
 	fprintf(myFile,"  coeff          = %17.9e\n", screwJoint->getScrewRatio());
 	fprintf(myFile,"/\n\n");
       }
-
-      if (jDesc.find("#JointLoadEngine") != std::string::npos)
-	ListUI <<"\n---> WARNING: Ignoring #JointLoadEngine"
-	       <<" in the description field for "<< activeJoint->getIdString()
-	       <<".\n     Use the \"Load magnitude\" field in the"
-	       <<" joint property window instead.\n";
     }
 
     // Write base springs and yield for all frictions that have stiffness
-    FmFrictionBase* activeFriction = activeJoint->getFriction();
-    if (activeFriction)
-      if (activeFriction->getStickStiffness() > 0.0)
+    if (FmFrictionBase* friction = activeJoint->getFriction(); friction)
+      if (friction->getStickStiffness() > 0.0)
       {
 	fprintf(myFile,"! Friction limit used by joint friction spring\n");
 	fprintf(myFile,"&SPRING_YIELD\n");
@@ -1446,7 +1376,7 @@ int FmSolverParser::writeJoints()
 	fprintf(myFile,"! Friction spring for joint or contact element\n");
 	fprintf(myFile,"&SPRING_BASE\n");
 	activeJoint->printID(myFile);
-	fprintf(myFile,"  s0 = %17.9e\n", activeFriction->getStickStiffness());
+	fprintf(myFile,"  s0 = %17.9e\n", friction->getStickStiffness());
 	fprintf(myFile,"  springYieldId = %d\n", activeJoint->getBaseID());
 	fprintf(myFile,"/\n\n");
       }
@@ -1470,12 +1400,6 @@ int FmSolverParser::writeRotationJointVars(const char* jointVarDefs,
     case FmJointBase::rZXY: iDof[0]=5; iDof[1]=3; iDof[2]=4; break;
     default: return 1;
     }
-
-  if (aJoint->getUserDescription().find("#RotAxisParam") != std::string::npos)
-    ListUI <<"\n---> WARNING: Ignoring #RotAxisParam"
-	   <<" in the description field for "<< aJoint->getIdString()
-	   <<".\n     Use the \"Rotation formulation\" menu in the"
-	   <<" \"Advanced\" tab of the joint property window instead.\n";
 
   int iMat[3];
   switch (aJoint->rotFormulation.getValue())
@@ -1505,13 +1429,7 @@ int FmSolverParser::writeContactElement(FmCamJoint* activeJoint)
   fprintf(myFile,"&CONTACT_ELEMENT\n");
   activeJoint->printID(myFile);
 
-  // Thickness and width of contact surface
-  if (activeJoint->getUserDescription().find("#Width") != std::string::npos)
-    ListUI <<"\n---> WARNING: Ignoring #Width <w>"
-	   <<" in the description field for "<< activeJoint->getIdString()
-	   <<".\n     Use the \"Width\" field"
-	   <<" in the joint property window instead.\n";
-
+  // Thickness/radius and width of contact surface
   if (activeJoint->isUsingRadialContact())
     fprintf(myFile,"  radius =%17.9e\n", activeJoint->getThickness());
   else
@@ -1584,7 +1502,6 @@ int FmSolverParser::writeFriction(FmJointBase* aJoint, const IntVec& iDof)
   // Beta feature: Hydro-, Skin- and Radial friction for pipes (DrillSim)
   FFaString fDesc = aFriction->getUserDescription();
   if (fDesc.hasSubString("#PipeRadius")) {
-    FFaString fDesc = aFriction->getUserDescription();
     double pipeRadius = fDesc.getDoubleAfter("#PipeRadius");
     double outerPipeRadius = fDesc.getDoubleAfter("#OuterPipeRadius");
     double hydroFric = fDesc.getDoubleAfter("#HydroFric");
@@ -1599,14 +1516,13 @@ int FmSolverParser::writeFriction(FmJointBase* aJoint, const IntVec& iDof)
 
   // Beta feature: User-defined normal force via an engine
   FFaString jDesc = aJoint->getUserDescription();
-  int fricFEngine = jDesc.getIntAfter("#FrictionForceEngine");
-  if (fricFEngine > 0) {
+  if (int engineId = jDesc.getIntAfter("#FrictionForceEngine"); engineId > 0) {
     for (i = 0; i < nDof; i++)
-      if (fId[i]) fId[i] = fricFEngine;
+      if (fId[i]) fId[i] = engineId;
     fprintf(myFile,"  frictionEngineId =");
     for (i = 0; i < nDof; i++)
       fprintf(myFile," %d", fId[i]);
-    FmEngine::betaFeatureEngines.insert(fricFEngine);
+    FmEngine::betaFeatureEngines.insert(engineId);
   }
 
   return true;
@@ -1680,21 +1596,17 @@ int FmSolverParser::writeSensors()
       int lerr = err;
       size_t nArgs = engine->getNoArgs();
       for (size_t j = 0; j < nArgs; j++)
-      {
-        // Avoid writing any sensors more than once.
-        // set<int>::insert() returns a pair<iterator,bool> where the bool
-        // tells whether the element was actually inserted or already present.
-        int sensorId = engine->getSensorId(j);
-        if (sensorId > 0 && writtenSensors.insert(sensorId).second)
-        {
-          FmSensorBase* sensor = engine->getSensor(j);
-          fprintf(myFile,"&SENSOR\n");
-          fprintf(myFile,"  id = %d\n",sensorId);
-          sensor->printID(myFile,false);
-          err += sensor->printSolverData(myFile,engine,j);
-          fprintf(myFile,"/\n\n");
-        }
-      }
+        if (int sensorId = engine->getSensorId(j); sensorId > 0)
+          // Avoid writing any sensors more than once
+          if (writtenSensors.insert(sensorId).second)
+          {
+            FmSensorBase* sensor = engine->getSensor(j);
+            fprintf(myFile,"&SENSOR\n");
+            fprintf(myFile,"  id = %d\n",sensorId);
+            sensor->printID(myFile,false);
+            err += sensor->printSolverData(myFile,engine,j);
+            fprintf(myFile,"/\n\n");
+          }
       if (err > lerr)
         ListUI <<"---> ERROR: "<< engine->getIdString(true) <<" is inconsistent\n";
     }

--- a/vpmDB/FmTriad.C
+++ b/vpmDB/FmTriad.C
@@ -419,7 +419,8 @@ bool FmTriad::setStatusForDOF(int dof, DOFStatus status)
 
 bool FmTriad::setDOFStatus(int DOF, DOFStatus status)
 {
-  if (!this->setStatusForDOF(DOF,status)) return false;
+  if (!this->setStatusForDOF(DOF,status))
+    return false;
 
   this->updateDisplayDetails();
   return true;
@@ -1044,12 +1045,9 @@ bool FmTriad::showDirections()
 bool FmTriad::importantDirections()
 {
   if (hasJointBinding())
-  {
-    if (isSlaveTriad(true))
+    if (isMasterTriad(true) || isSlaveTriad(true))
       return true;
-    else if (isMasterTriad(true))
-      return true;
-  }
+
   if (getSimpleSensor()) return true;
   if (hasConstraints())  return true;
 
@@ -1131,9 +1129,8 @@ FmJointBase* FmTriad::getJointWhereSlave() const
   this->getReferringObjs(joints,"itsSlaveTriad");
 
   for (FmJointBase* joint : joints)
-    if (!joint->isContactElement())
-      if (!joint->isGlobalSpringElement())
-        return joint;
+    if (!joint->isContactElement() && !joint->isGlobalSpringElement())
+      return joint;
 
   return NULL;
 }
@@ -1207,9 +1204,8 @@ bool FmTriad::isSlaveTriad(bool realSlavesOnly) const
   for (FmJointBase* joint : joints)
     if (!realSlavesOnly)
       return true;
-    else if (!joint->isContactElement())
-      if (!joint->isGlobalSpringElement())
-        return true;
+    else if (!joint->isContactElement() && !joint->isGlobalSpringElement())
+      return true;
 
   return false;
 }
@@ -1227,9 +1223,8 @@ bool FmTriad::isMasterTriad(bool realMastersOnly) const
   for (FmJointBase* joint : joints)
     if (!realMastersOnly)
       return true;
-    else if (!joint->isContactElement())
-      if (!joint->isGlobalSpringElement())
-        return true;
+    else if (!joint->isContactElement() && !joint->isGlobalSpringElement())
+      return true;
 
   return false;
 }
@@ -1478,9 +1473,12 @@ FaMat34 FmTriad::getGlobalCS() const
 
 FaMat34 FmTriad::getRelativeCS(const FmLink* link) const
 {
-  const FmPart* part = dynamic_cast<const FmPart*>(link);
-  if (!link || (part && part == this->getOwnerPart(0)))
+  if (!link)
     return this->getLocalCS();
+
+  if (const FmPart* part = dynamic_cast<const FmPart*>(link); part)
+    if (part == this->getOwnerPart(0))
+      return this->getLocalCS();
 
   return link->getGlobalCS().inverse() * this->getGlobalCS();
 }
@@ -1713,9 +1711,13 @@ bool FmTriad::readAndConnect(std::istream& is, std::ostream&)
   };
 
   // Obsolete fields
-  FFaObsoleteField<double>  geoTol;
-  FFaObsoleteField<BoolVec> oldBndC;
+
+#ifdef FT_USE_CONNECTORS
+  FFaObsoleteField<double> geoTol;
   FFA_OBSOLETE_FIELD_INIT(geoTol, 0.0, "CONNECTOR_GEOMETRY_TOLERANCE", obj);
+#endif
+
+  FFaObsoleteField<BoolVec> oldBndC;
   FFA_OBSOLETE_FIELD_DEFAULT_INIT(oldBndC, "ADD_BND", obj);
 
   while (is.good())
@@ -1729,20 +1731,18 @@ bool FmTriad::readAndConnect(std::istream& is, std::ostream&)
   FFA_OBSOLETE_FIELD_REMOVE("CONNECTOR_GEOMETRY_TOLERANCE", obj);
   FFA_OBSOLETE_FIELD_REMOVE("ADD_BND", obj);
 
-#ifdef FT_USE_CONNECTORS
   // Update from old model file
+
+#ifdef FT_USE_CONNECTORS
   if (geoTol.wasOnFile())
     obj->itsConnectorGeometry.getValue().setTolerance(geoTol.getValue());
 #endif
 
-  FFaString tDesc = obj->getUserDescription();
   if (oldBndC.wasOnFile())
-  {
-    DOFStatus newDS = tDesc.hasSubString("#DynBC") ? FIXED : FREE_DYNAMICS;
     for (size_t dof = 0; dof < oldBndC.getValue().size(); dof++)
-      if (oldBndC.getValue()[dof]) obj->setStatusForDOF(dof,newDS);
-  }
+      if (oldBndC.getValue()[dof]) obj->setStatusForDOF(dof,FREE_DYNAMICS);
 
+  const FFaString tDesc = obj->getUserDescription();
   if (tDesc.hasSubString("#SysDir"))
     obj->itsLocalDir.setValue((LocalDirection)tDesc.getIntAfter("#SysDir"));
 
@@ -1915,22 +1915,20 @@ int FmTriad::printSolverEntry(FILE* fp)
     else
     {
       const double* v0 = NULL;
+
+      // Global initial velocity that should apply to all triads
+      // that don't have their own initial velocity
+      if (const FaVec3& glbVel = FmDB::getMechanismObject()->initVel.getValue();
+          !glbVel.isZero())
+        v0 = glbVel.getPt();
+
       double linkVel[3];
       if (FmLink* triadOwner = this->getOwnerLink(); triadOwner)
-      {
         // Beta feature: Initial translational velocity on link level
-        FFaString lDesc = triadOwner->getUserDescription();
-        if (lDesc.getDoublesAfter("#InitTransVel",3,linkVel) > 0)
+        if (const FFaString lDesc = triadOwner->getUserDescription();
+            lDesc.getDoublesAfter("#InitTransVel",3,linkVel) > 0)
           v0 = linkVel;
-      }
-      if (!v0)
-      {
-        // Global initial velocity that should apply to all triads
-        // that don't have their own initial velocity
-        const FaVec3& globVel = FmDB::getMechanismObject()->initVel.getValue();
-        if (!globVel.isZero())
-          v0 = globVel.getPt();
-      }
+
       if (v0)
       {
         // Initial velocity on link or global level
@@ -1950,7 +1948,7 @@ int FmTriad::printSolverEntry(FILE* fp)
     }
 
     // Beta feature: Parameters for distributed drag calculations
-    FFaString tDesc = this->getUserDescription();
+    const FFaString tDesc = this->getUserDescription();
     double dragParams[9];
     if (tDesc.getDoublesAfter("#DragTX",3,dragParams)   |
         tDesc.getDoublesAfter("#DragTY",3,dragParams+3) |
@@ -2031,7 +2029,7 @@ int FmTriad::printAdditionalMass(FILE* fp)
   fprintf(fp,"  triadId = %d",this->getBaseID());
 
   // Beta feature: Added mass and direction-dependent mass
-  FFaString tDesc = this->getUserDescription();
+  const FFaString tDesc = this->getUserDescription();
   FaVec3 mass(this->getAddMass(),0.0,0.0);
   int mDof = 0;
   if (tDesc.hasSubString("#AddedMass"))
@@ -2173,8 +2171,8 @@ char FmTriad::isRotatable(const FmJointBase* jointToIgnore) const
   std::vector<FmSMJointBase*> joints1;
   this->getReferringObjs(joints1,"itsMasterTriad");
   for (FmSMJointBase* joint : joints1)
-    if (joint->isMasterMovedAlong())
-      if (joint != jointToIgnore) return false;
+    if (joint->isMasterMovedAlong() && joint != jointToIgnore)
+      return false;
 
   // Check if this is an independent triad of a prismatic or cylindric joint
   // with its orientation defined by EulerZYX angles
@@ -2297,9 +2295,10 @@ FmTriad* FmTriad::createAtNode(FFlNode* node, FmBase* parent,
 {
   if (!node) return NULL;
 
-  FmBase* triad = FmDB::findID(FmTriad::getClassTypeID(),
-                               IDoffset+node->getID(), {parent->getID()});
-  if (triad) return static_cast<FmTriad*>(triad);
+  if (FmBase* oldTriad = FmDB::findID(FmTriad::getClassTypeID(),
+                                      IDoffset+node->getID(),
+                                      {parent->getID()}); oldTriad)
+    return static_cast<FmTriad*>(oldTriad);
 
   FmTriad* newTriad = new FmTriad(node->getPos());
   newTriad->setParentAssembly(parent);


### PR DESCRIPTION
This fixes #44 first of all.
A new hash-command `#UseEngines` is added in the Model Preferences field.
Remove messages when detecting obsolete hash-commands.
These are long gone by now and not likely there are many models around where they were in use.